### PR TITLE
Add banking complaints MCP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 vibeslop is a playground for vibe coding AI Agents using various frameworks and technologies such as [langgraph](https://github.com/), the [a2a](https://github.com/) project, and [MCP servers](https://github.com/).
 
 See [GOALS.md](GOALS.md) for high-level objectives.
+
+## Subprojects
+
+- **Banking Complaints Agent**: a minimal MCP server that fronts the [CFPB Consumer Complaints API](https://www.consumerfinance.gov/data-research/consumer-complaints/search/api/v1/). See [banking_complaints_agent/README.md](banking_complaints_agent/README.md) for details.

--- a/banking_complaints_agent/README.md
+++ b/banking_complaints_agent/README.md
@@ -1,0 +1,20 @@
+# Banking Complaints Agent
+
+This subproject provides a simple Model Context Protocol (MCP) server that 
+fronts the public CFPB Consumer Complaints API. It exposes a `/complaints`
+endpoint that accepts query parameters and forwards them to the CFPB API.
+
+The server uses FastAPI and does not require any additional third-party HTTP
+libraries. To run the server locally:
+
+```bash
+uvicorn banking_complaints_agent.server:app --reload
+```
+
+Example request:
+
+```bash
+curl 'http://localhost:8000/complaints?search=credit%20card&size=5'
+```
+
+This will forward the request to the CFPB API and return the result.

--- a/banking_complaints_agent/server.py
+++ b/banking_complaints_agent/server.py
@@ -1,0 +1,34 @@
+from fastapi import FastAPI, HTTPException
+from typing import Optional, Dict, Any
+import json
+import urllib.request
+from urllib.parse import urlencode
+
+API_BASE = "https://www.consumerfinance.gov/data-research/consumer-complaints/search/api/v1/"
+
+app = FastAPI(title="Banking Complaints Agent MCP Server")
+
+
+def fetch_cfpb(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Fetch data from the CFPB complaints API."""
+    query = urlencode(params)
+    url = API_BASE + "?" + query
+    try:
+        with urllib.request.urlopen(url) as resp:
+            if resp.status != 200:
+                raise HTTPException(status_code=resp.status, detail="CFPB API error")
+            data = resp.read()
+            return json.loads(data.decode())
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@app.get("/complaints")
+async def get_complaints(search: Optional[str] = None, company: Optional[str] = None, size: int = 10):
+    """Proxy endpoint that returns complaints from the CFPB API."""
+    params: Dict[str, Any] = {"size": size}
+    if search:
+        params["searchTerm"] = search
+    if company:
+        params["company"] = company
+    return fetch_cfpb(params)

--- a/banking_complaints_agent/tests/test_server.py
+++ b/banking_complaints_agent/tests/test_server.py
@@ -1,0 +1,35 @@
+import json
+import urllib.request
+import unittest
+from unittest.mock import patch
+from banking_complaints_agent.server import fetch_cfpb
+
+
+class TestFetchCFPB(unittest.TestCase):
+    def test_fetch_cfpb(self):
+        sample_data = {"hits": {"total": 1, "hits": [{"_source": {"company": "Test"}}]}}
+
+        class DummyResponse:
+            def __init__(self, data, status=200):
+                self._data = data
+                self.status = status
+
+            def read(self):
+                return json.dumps(self._data).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                pass
+
+        def dummy_urlopen(url):
+            return DummyResponse(sample_data)
+
+        with patch.object(urllib.request, "urlopen", dummy_urlopen):
+            result = fetch_cfpb({"searchTerm": "test", "size": 1})
+            self.assertEqual(result, sample_data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- build a basic MCP server for the Banking Complaints Agent
- document usage in new README
- list project in root README
- add tests for `fetch_cfpb`
- ignore Python bytecode files

## Testing
- `python3 -m unittest discover -s banking_complaints_agent/tests -v`
