### PR TITLE
Add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,13 @@
 # Repository Instructions
 
+## Setup
+Install dependencies with:
+```bash
+pip install -r requirements.txt
+```
+
 ## Running tests
 Run the unit tests with:
-
 ```bash
 python -m unittest discover -s banking_complaints_agent/tests -v
 ```
@@ -11,5 +16,9 @@ python -m unittest discover -s banking_complaints_agent/tests -v
 Place your Groq API key in `banking_complaints_agent/groq_api_key.txt`. This file should contain the key on a single line and is ignored by Git.
 
 ## Coding conventions
-There are currently no specific linting rules or formatters configured. Follow standard PEP8 style guidelines for Python code.
+Follow standard PEP8 style guidelines for Python code. No additional linters are configured.
 
+## Notes
+The agent environment does not have network access during test execution. Tests should not rely on external services.
+
+See each subdirectory's `AGENTS.md` for project-specific instructions.

--- a/banking_complaints_agent/AGENTS.md
+++ b/banking_complaints_agent/AGENTS.md
@@ -1,0 +1,26 @@
+# Banking Complaints Agent Instructions
+
+## Running tests
+Use unittest to run subproject tests:
+```bash
+python -m unittest discover -s tests -v
+```
+
+## Setup
+Install dependencies from the repository root:
+```bash
+pip install -r ../requirements.txt
+```
+
+A Groq API key is required for the natural-language agent. Place it in `groq_api_key.txt` (one line containing the key). The file is ignored by Git.
+
+## Running the server
+To launch the MCP server:
+```bash
+python server.py --transport http --host 0.0.0.0 --port 8000
+```
+
+To start the A2A façade:
+```bash
+MCP_URL=http://localhost:8000/complaints python a2a_facade.py
+```

--- a/banking_complaints_mcp/AGENTS.md
+++ b/banking_complaints_mcp/AGENTS.md
@@ -1,0 +1,18 @@
+# Banking Complaints MCP Instructions
+
+This directory contains an MCP server that exposes the CFPB Consumer Complaint data.
+
+## Setup
+Use Python 3.11+. Install dependencies with:
+```bash
+pip install -e .
+```
+(or run `uv pip install -e .` if using the `uv` tool.)
+
+## Running
+Start the server via:
+```bash
+python complaints.py
+```
+
+There are currently no automated tests for this subproject.

--- a/onefileollamaclient/AGENTS.md
+++ b/onefileollamaclient/AGENTS.md
@@ -1,0 +1,6 @@
+# One-File Ollama Client Instructions
+
+This directory contains static HTML pages demonstrating a simple Ollama client.
+
+These HTML files are single-file, single-page applications. Everything (HTML, CSS, and JavaScript) is embedded directly in the file, so there are no external dependencies. Open `ollamaclient.html` or `glassmorphic-ollama-client.html` in any modern web browser to use the client.
+


### PR DESCRIPTION
## Summary
- expand root `AGENTS.md` with setup and notes
- add `AGENTS.md` to each subdirectory to document usage
- clarify that the one-file HTML clients are fully self-contained

## Testing
- `python -m unittest discover -s banking_complaints_agent/tests -v` *(fails: No module named 'fastmcp')*