### PR TITLE
Skip Win95 boot splash overlay

### DIFF
--- a/win95sim/index.html
+++ b/win95sim/index.html
@@ -459,7 +459,7 @@
 </head>
 <body>
   <div id="app-shell">
-    <div id="boot-splash" role="alert" aria-live="assertive">Starting Windows 95...</div>
+    <div id="boot-splash" role="alert" aria-live="assertive" hidden>Starting Windows 95...</div>
     <div id="monitor">
       <div id="crt" data-scale="pixel">
         <div id="desktop-root" role="application" aria-label="Windows 95 Desktop"></div>


### PR DESCRIPTION
## Summary
- hide the boot splash overlay by default so the desktop is immediately visible on load

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f64623c0508329b990484c78b5cd5d