### PR TITLE
Ensure boot splash stays hidden on load

### DIFF
--- a/win95sim/index.html
+++ b/win95sim/index.html
@@ -400,6 +400,10 @@
       letter-spacing: 2px;
     }
 
+    #boot-splash[hidden] {
+      display: none !important;
+    }
+
     #system-menu {
       position: absolute;
       display: none;


### PR DESCRIPTION
## Summary
- ensure the boot splash respects the hidden attribute so it does not flash during load

## Testing
- node --test win95sim/tests/phase1.test.js win95sim/tests/phase2.test.js win95sim/tests/phase3.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f64ea05dbc8329a062c2d0bab1b71d