### PR TITLE
Add comprehensive win95sim v2 documentation and scaffolding

### DIFF
--- a/win95sim_v2/AGENTS.md
+++ b/win95sim_v2/AGENTS.md
@@ -1,0 +1,26 @@
+# Win95Sim V2 Instructions
+
+## Project intent
+- Deliver Win95Sim as a modular multi-file application rooted in the `src/` workspace and emitted to a distributable `dist/` bundle.
+- Adopt the ten-phase roadmap captured in `planning/` with the mandate that Phase 01 lays the shared platform foundation so Phases 02–10 can develop in parallel without merge conflicts.
+- Maintain forward compatibility with the legacy single-file simulator by exposing equivalent public services and shell affordances documented in `docs/module-apis-v2.md`.
+
+## Coding guidelines
+- Follow the layered architecture defined in `docs/architecture.md`: `core/` → `services/` → `features/` → `apps/` → `shell/` and shared `ui/` primitives. Higher layers may depend only on the layers beneath them.
+- Modules must register through the `createModuleRegistry` contract and expose typed interfaces declared in `docs/module-apis-v2.md`.
+- Keep build outputs deterministic. Bundle tooling must support incremental builds so phase teams can integrate without touching other packages.
+- Use the shared CSS tokens under `src/ui/tokens.css` (to be created in Phase 01) rather than hard-coded metrics or colors.
+- Add new third-party dependencies only inside `package.json` and document them in `docs/assets.md`.
+
+## Testing & QA
+- Node unit tests live in `tests/` and should mirror the phase roadmap (`phase01-window-manager.test.js`, etc.). Use Node's native test runner.
+- Browser automation, visual, and accessibility coverage should target the built `dist/` output per `planning/testing-strategy.md`.
+- Before closing a phase, complete the manual QA checklist in `planning/qa-checklists/` and log outcomes in the phase doc.
+
+## Documentation expectations
+- Update architecture, implementation phases, risk log, and parity references whenever a shared contract changes.
+- Record new shared APIs in `docs/module-apis-v2.md` and surface risks that could impact concurrent teams.
+
+## Collaboration & concurrency
+- Respect the workspace ownership map in `docs/architecture.md`. Do not modify folders owned by another phase without coordination.
+- Keep shared `core/` and `services/` code backward compatible. Breaking changes require RFC notes in `planning/phase-01-window-manager.md` and sign-off from dependent phase owners.

--- a/win95sim_v2/README.md
+++ b/win95sim_v2/README.md
@@ -1,0 +1,66 @@
+# Win95Sim V2
+
+Win95Sim V2 re-imagines the original single-file Windows 95 simulator as a modular, multi-file web application. The new workspace separates concerns across packages so teams can collaborate in parallel after the shared desktop shell lands in Phase 01.
+
+## Why a V2?
+- **Scalable architecture** – Source lives under `src/` by domain: foundational `core/`, cross-cutting `services/`, composable `features/`, individual `apps/`, and the desktop `shell/`.
+- **Concurrent delivery** – Once the platform baseline is complete, phases 02–10 can advance simultaneously with minimal merge contention.
+- **Tooling-first workflow** – Dedicated build steps emit a production `dist/` bundle while preserving a modular developer experience.
+
+## Repository layout
+```
+win95sim_v2/
+├── AGENTS.md              # Development guardrails and collaboration contract
+├── README.md              # You are here
+├── docs/                  # Architecture, API, and asset references
+├── planning/              # Phase playbooks, QA checklists, risk log
+├── references/            # Feature parity matrix, UI guidelines, shared research
+├── src/                   # (Phase 01) Source code organized by layer
+├── tests/                 # Node test suites aligned to each phase
+└── tools/                 # (Phase 01) Build and packaging scripts
+```
+`src/` and `tools/` will be created during Phase 01. Their ownership and responsibilities are already defined in `docs/architecture.md` so downstream teams can plan their work.
+
+## Getting started
+1. Install dependencies (Phase 01 will introduce the root `package.json`):
+   ```bash
+   npm install
+   ```
+2. Run the Node unit tests:
+   ```bash
+   npm test
+   ```
+3. Build the distributable bundle:
+   ```bash
+   npm run build
+   ```
+
+> ⚠️ Scripts will be wired up once Phase 01 lands. The commands above describe the expected developer experience.
+
+## Development principles
+- Stabilize shared contracts (module APIs, CSS tokens, event buses) before parallelizing work.
+- Keep each phase within its assigned folders to avoid cross-team churn.
+- Document all new capabilities, assets, and risks as you build them.
+
+## Roadmap snapshot
+The planning folder captures detailed guidance for each phase. Highlights:
+- **Phase 01** – Multi-window desktop shell, module registry, asset pipeline, shared UI tokens.
+- **Phase 02** – Virtual file system explorer powered by the new data services.
+- **Phase 03** – Command shell + scripting engine.
+- **Phase 04** – Notepad and dialog frameworks.
+- **Phase 05** – Internet Explorer-like navigator.
+- **Phase 06** – Paint & media utilities.
+- **Phase 07** – Games and accessories.
+- **Phase 08** – Control Panel and printers.
+- **Phase 09** – Polish, accessibility, localization.
+- **Phase 10** – Packaging, deployment, and long-term support.
+
+Consult the corresponding QA checklists and risk log before shipping any phase milestone.
+
+## Contributing
+1. Coordinate ownership in `planning/phase-01-window-manager.md` and the architecture doc.
+2. Keep pull requests focused on a single phase deliverable.
+3. Update documentation and tests alongside code changes.
+
+## License
+Win95Sim V2 inherits the original Win95Sim licensing. Confirm third-party asset compatibility via `docs/assets.md` before merging.

--- a/win95sim_v2/docs/architecture.md
+++ b/win95sim_v2/docs/architecture.md
@@ -1,0 +1,69 @@
+# Architecture Overview
+
+Win95Sim V2 converts the legacy single-file simulator into a modular workspace that can scale across teams. The design prioritizes:
+- **Separation of concerns** so features evolve independently.
+- **Stable contracts** that keep downstream packages unblocked.
+- **Deterministic builds** that ship a cohesive `dist/` bundle for the browser.
+
+## Layered workspace
+```
+src/
+├── core/            # Kernel primitives: scheduler, message bus, window composition
+├── services/        # Shared data/service APIs (state, storage, i18n, telemetry)
+├── features/        # Cross-cutting UI behaviors (taskbar, notifications, drag/drop)
+├── apps/            # Individual Win95 experiences (Explorer, Notepad, Paint, etc.)
+├── shell/           # Desktop shell, boot flow, session orchestration
+└── ui/              # Design tokens, theming, layout primitives, reusable controls
+```
+
+- **Core** exposes the runtime foundation and owns the module registry (`createModuleRegistry`).
+- **Services** provide injectable contracts consumed by features/apps. They can depend on `core/` but not vice versa.
+- **Features** deliver composable experiences used by apps and the shell (e.g., window chrome, context menus).
+- **Apps** implement Win95 programs using services + features.
+- **Shell** bootstraps the desktop, orchestrates the taskbar/start menu, and hosts app windows.
+- **UI** centralizes styling (CSS custom properties, mixins) and shared web components.
+
+Ownership is assigned per phase. After Phase 01, each team can operate largely within its sub-tree:
+- Phase 02 – `apps/explorer/`, `services/filesystem/`
+- Phase 03 – `apps/command-shell/`, `services/processes/`
+- Phase 04 – `apps/notepad/`, `features/dialogs/`
+- Phase 05 – `apps/navigator/`, `services/networking/`
+- Phase 06 – `apps/paint/`, `features/media/`
+- Phase 07 – `apps/games/`
+- Phase 08 – `apps/control-panel/`, `services/devices/`
+- Phase 09 – Shared polish in `ui/`, `shell/`
+- Phase 10 – `tools/`, release automation
+
+## Build pipeline
+Phase 01 introduces a Node-based build orchestrator under `tools/`:
+1. **Type checking** (TS or JSDoc) against shared interfaces.
+2. **Bundling** via Vite/Rollup configuration that emits:
+   - `dist/index.html` bootstrapper loading modular scripts.
+   - `dist/assets/` for lazy-loaded bundles, audio, imagery (kept small, documented in `docs/assets.md`).
+3. **Testing** – `npm test` for unit suites, `npm run test:e2e` for Playwright once configured.
+4. **Distribution** – `npm run package` zips the `dist/` folder and generates hashes for release notes.
+
+Build steps enforce dependency boundaries using lint rules (e.g., `eslint-plugin-boundaries`) configured in Phase 01.
+
+## Module registry & loading
+- Modules register via `createModuleRegistry({ id, factory, exports })`.
+- Each package exposes a manifest (`module.json`) consumed by the build step to assemble dependency graphs.
+- Runtime loading uses dynamic `import()` with chunk prefetch hints to keep the boot path fast.
+
+## State management
+- Core provides an event-driven state store similar to Redux but optimized for message-bus broadcasting.
+- Services expose domain-specific controllers (filesystem, process manager) with typed events.
+- UI state that crosses apps (e.g., focused window) flows through the `shell/session` service to avoid duplication.
+
+## Concurrency safeguards
+- Shared contracts live in `core/` and `services/`. Updates require RFC approval captured in `planning/phase-01-window-manager.md`.
+- Phases own their directories and can deliver features independently after Phase 01.
+- Code owners configure Git to require approvals when touching another team's folder (documented in the Phase 01 plan).
+
+## Extension & compatibility
+- Preserve parity with Win95Sim v1 by keeping exported shell APIs (window manager, taskbar API) compatible. Mapping tables live in `docs/module-apis-v2.md`.
+- Provide migration helpers so existing automation scripts can bind to the new module IDs.
+
+## Future considerations
+- Investigate WebAssembly modules for CPU-intensive features (e.g., audio mixing) once the modular pipeline is stable.
+- Explore optional service workers for offline caching in Phase 09.

--- a/win95sim_v2/docs/assets.md
+++ b/win95sim_v2/docs/assets.md
@@ -1,0 +1,59 @@
+# Asset & Licensing Guidelines
+
+The multi-file architecture changes how we organize and ship assets. Follow these rules to keep the bundle size low and licensing clear.
+
+## Directory layout
+```
+src/
+  assets/
+    audio/
+    fonts/
+    icons/
+    wallpapers/
+dist/
+  assets/
+    audio/
+    fonts/
+    icons/
+    wallpapers/
+```
+- Place raw source assets under `src/assets/` and reference them from manifests.
+- The build pipeline optimizes and copies assets into `dist/assets/`.
+
+## Size budgets
+- Individual audio files ≤ 500 KB (compressed Ogg/MP3).
+- Icons ≤ 32 KB (PNG) and also export 16×16 and 32×32 variants.
+- Wallpaper images ≤ 400 KB (JPEG/WebP).
+- Total `dist/` size target: ≤ 10 MB.
+
+## Attribution tracking
+Maintain `docs/assets-attribution.csv` (created during Phase 01) with:
+- Asset name & path
+- Source URL / license
+- Notes on modifications
+
+Additions must update:
+1. The CSV registry
+2. `references/ui-guidelines.md` if the asset affects UI patterns
+3. The About dialog copy (Phase 05 owner)
+
+## Build tooling
+Phase 01 introduces:
+- Image compression via `sharp`
+- Audio normalization via `ffmpeg` (optional, document CLI usage)
+- Hash-based cache busting for `dist/assets/`
+
+Developers should run:
+```bash
+npm run assets:optimize
+```
+prior to committing large asset changes (script to land in Phase 01).
+
+## Licensing checklist
+- Confirm permissive licenses (CC-BY, CC0, MIT). Avoid GPL assets.
+- Record attribution text in the CSV and in release notes when applicable.
+- Store proof-of-license screenshots in `references/assets/` (Phase 01 will add the folder).
+
+## Localization & accessibility
+- Provide alt text or aria labels for decorative imagery in the metadata manifests.
+- Localize audio transcripts where applicable during Phase 09.

--- a/win95sim_v2/docs/implementation-phases.md
+++ b/win95sim_v2/docs/implementation-phases.md
@@ -1,0 +1,32 @@
+# Implementation Phases
+
+The roadmap mirrors the original Win95Sim goals while accommodating the multi-file workspace. Phase 01 establishes the shared foundation so remaining phases can execute in parallel.
+
+| Phase | Focus | Key Deliverables | Dependencies |
+|-------|-------|------------------|--------------|
+| 01 | Desktop shell & tooling | Module registry, window manager, build tooling, lint/test config, CSS token library | None (bootstrapping) |
+| 02 | Virtual File System Explorer | Explorer app, filesystem service, desktop icons | Phase 01 platform |
+| 03 | Command Shell | Terminal UI, scripting runtime, process service integrations | Phase 01 platform |
+| 04 | Productivity Apps | Notepad app, dialog framework, clipboard integration | Phases 01, 02 (read-only FS) |
+| 05 | Navigator & Web Stack | Navigator app, networking service, HTML renderer bridge | Phases 01, 02 |
+| 06 | Paint & Media | Paint app, media service, bitmap editor components | Phases 01, 02 |
+| 07 | Games & Utilities | Minesweeper, Solitaire, calculator, sound recorder | Phase 01 platform |
+| 08 | Control Panel & Devices | Settings hub, printer manager, driver manifests | Phases 01, 02 |
+| 09 | Polish & Accessibility | Localization, high contrast mode, performance & QA | Phases 01–08 |
+| 10 | Packaging & Release | Build final `dist/`, telemetry opt-in, documentation freeze | Phases 01–09 |
+
+## Phase sequencing & concurrency
+- **Phase 01** builds the module registry, dependency graph, CSS tokens, and base shell. It also writes the code ownership map and `tools/` build scripts.
+- After **Phase 01** lands, phases 02–10 proceed concurrently. Shared dependencies (e.g., services) provide stubs so teams can work without blocking each other.
+- Each phase maintains compatibility with the contracts in `docs/module-apis-v2.md`. Breaking changes require cross-phase coordination logged in the risk log.
+
+## Definition of done
+Every phase must:
+1. Ship automated tests (`tests/phaseXX-*.test.js` or Playwright suites).
+2. Update relevant planning docs with status, risks, and QA results.
+3. Produce updated documentation (architecture, assets, parity matrix) when shared contracts move.
+4. Generate release notes entry describing user-facing behavior.
+
+## Release trains
+- We target a minor release after each phase milestone. Phases completing concurrently can share a release train if they pass integration tests.
+- Release management (Phase 10) owns tagging, changelog compilation, and CDN publishing.

--- a/win95sim_v2/docs/module-apis-v2.md
+++ b/win95sim_v2/docs/module-apis-v2.md
@@ -1,0 +1,147 @@
+# Module APIs (V2)
+
+The V2 simulator exposes stable contracts to keep teams productive while working in parallel. The APIs below must remain backward compatible with the original single-file release unless a version bump is coordinated across phases.
+
+## Registry primitives
+```ts
+import { createModuleRegistry } from 'core/runtime/registry';
+
+const registry = createModuleRegistry();
+
+registry.register({
+  id: 'shell/taskbar',
+  version: '2.0.0',
+  exports: () => new TaskbarController(options)
+});
+```
+- `id` follows the pattern `<layer>/<module>` (e.g., `services/filesystem`).
+- `version` is semver. Increment minor for backward-compatible additions, major for breaking changes.
+- `exports` returns the public surface (object instance or function map).
+
+## Core runtime
+### `core/runtime/session`
+Responsible for boot orchestration and window focus management.
+```ts
+interface SessionService {
+  boot(): Promise<void>;
+  openApp(manifestId: string, params?: Record<string, unknown>): Promise<AppHandle>;
+  getActiveWindow(): WindowHandle | null;
+  subscribe(listener: (event: SessionEvent) => void): () => void;
+}
+```
+Events include `session:ready`, `window:activated`, `window:closed`, `app:error`.
+
+### `core/runtime/windows`
+Controls window lifecycle and layout.
+```ts
+interface WindowManager {
+  create(config: WindowConfig): WindowHandle;
+  move(handle: WindowHandle, position: DOMRectInit): void;
+  resize(handle: WindowHandle, dimensions: { width: number; height: number }): void;
+  focus(handle: WindowHandle): void;
+  close(handle: WindowHandle): void;
+}
+```
+
+## Shared services
+### `services/filesystem`
+Phase 02 owner. Phase 01 stubs provide in-memory storage.
+```ts
+interface FileSystemService {
+  read(path: string): Promise<FileNode>;
+  write(path: string, contents: Uint8Array | string): Promise<void>;
+  list(path: string): Promise<FileNode[]>;
+  watch(path: string, handler: (event: FileEvent) => void): () => void;
+}
+```
+
+### `services/processes`
+Coordinates background tasks and shell processes.
+```ts
+interface ProcessService {
+  spawn(manifestId: string, args?: Record<string, unknown>): Promise<ProcessHandle>;
+  kill(pid: string): Promise<void>;
+  subscribe(handler: (event: ProcessEvent) => void): () => void;
+}
+```
+
+### `services/localization`
+Provides translation catalogs and locale helpers.
+```ts
+interface LocalizationService {
+  setLocale(locale: string): Promise<void>;
+  translate(key: string, params?: Record<string, string>): string;
+  subscribe(handler: (event: { locale: string }) => void): () => void;
+}
+```
+
+## UI primitives
+### CSS tokens (`ui/tokens.css`)
+```css
+:root {
+  --win95-color-window: #c3c7cb;
+  --win95-color-windowframe: #000000;
+  --win95-color-highlight: #0a64ad;
+  --win95-color-highlight-text: #ffffff;
+  --win95-font-ui: 'MS Sans Serif', 'Segoe UI', sans-serif;
+  --win95-border-size: 2px;
+  --win95-radius: 0;
+  --motion-duration-fast: 70ms;
+  --motion-duration-standard: 150ms;
+}
+```
+All UI code must consume these tokens through CSS custom properties or the helper functions provided in `ui/styles.ts` (Phase 01).
+
+### Window chrome helpers (`features/window-chrome`)
+```ts
+interface WindowChromeAPI {
+  attach(handle: WindowHandle, host: HTMLElement): void;
+  detach(handle: WindowHandle): void;
+  enableResize(handle: WindowHandle, options?: ResizeOptions): void;
+  enableDrag(handle: WindowHandle, options?: DragOptions): void;
+}
+```
+
+## App lifecycle
+Apps are declared via manifests under `apps/<name>/module.json`:
+```json
+{
+  "id": "apps/notepad",
+  "name": "Notepad",
+  "entry": "./index.ts",
+  "icon": "./icons/notepad.png",
+  "permissions": ["filesystem.read", "filesystem.write"],
+  "windows": [
+    {
+      "id": "main",
+      "title": "Untitled - Notepad",
+      "size": { "width": 480, "height": 320 }
+    }
+  ]
+}
+```
+The build pipeline validates manifests for conflicting IDs and missing permissions during Phase 01.
+
+## Telemetry & diagnostics
+Phase 10 introduces optional telemetry via `services/diagnostics`. Until then, the interface is stubbed:
+```ts
+interface DiagnosticsService {
+  log(event: string, payload?: Record<string, unknown>): void;
+  flush(): Promise<void>;
+}
+```
+
+## Compatibility layer
+`core/compat/v1-adapter` exposes shims that mimic the original global functions:
+```ts
+interface LegacyAdapter {
+  openWindow(id: string, opts?: Record<string, unknown>): Promise<WindowHandle>;
+  closeWindow(id: string): void;
+}
+```
+Use the adapter only for existing automation. New code must use the typed interfaces above.
+
+## Versioning & change control
+- Breaking changes require a major version bump and a changelog entry in `docs/architecture.md`.
+- Additive changes should ship alongside updated unit tests and QA checklist entries.
+- Deprecations must remain operable for at least two release cycles and be tracked in the risk log.

--- a/win95sim_v2/docs/vision.md
+++ b/win95sim_v2/docs/vision.md
@@ -1,0 +1,26 @@
+# Vision
+
+Win95Sim V2 celebrates the nostalgia of Windows 95 while modernizing the engineering foundation. The goal is a delightful, high-fidelity recreation that can grow with community contributions.
+
+## Experience principles
+- **Pixel-perfect authenticity** – Preserve the recognizable Win95 aesthetic, sounds, and interaction model.
+- **Approachable for newcomers** – Provide clear onboarding and documentation so contributors can explore the codebase quickly.
+- **Performant on modest hardware** – Optimize bundles and runtime to run smoothly on low-powered devices.
+- **Inclusive & accessible** – Ensure keyboard navigation, screen reader support, and configurable motion preferences are first-class features.
+
+## Engineering principles
+- **Modular everything** – Break functionality into reusable packages with explicit contracts.
+- **Parallel-friendly** – Architect modules so multiple teams can build features simultaneously without conflicts.
+- **Documented rigorously** – Keep architecture, APIs, and QA processes transparent and current.
+- **Test-driven** – Pair features with automated and manual tests to maintain quality.
+
+## Success metrics
+- `≤ 3s` cold boot on a mid-range laptop (once assets cached).
+- `≤ 10 MB` production bundle size.
+- 100% of new features shipping with automated tests and QA checklists completed.
+- Zero blocking merge conflicts between phases after Phase 01 due to shared ownership map.
+
+## Looking ahead
+- Community-curated themes & optional enhancements once the modular pipeline is stable.
+- Optional compatibility layer for importing legacy `.lnk` shortcuts.
+- Cloud sync of settings in a future phase (post-Phase 10 exploration).

--- a/win95sim_v2/planning/README.md
+++ b/win95sim_v2/planning/README.md
@@ -1,0 +1,17 @@
+# Planning Overview
+
+This directory mirrors the original Win95Sim planning set with updates for the modular workspace.
+
+## Structure
+- `phase-*.md` – Detailed implementation guides per phase with objectives, deliverables, and ownership.
+- `qa-checklists/` – Manual validation steps before declaring a phase complete.
+- `testing-strategy.md` – Automation roadmap across unit, integration, visual, and accessibility coverage.
+- `risk-log.md` – Shared risks, mitigations, and owners.
+
+## Concurrency readiness
+Phase 01 defines the governance model that allows phases 02–10 to develop simultaneously:
+- Shared contracts (`core/`, `services/`) gain versioning and change-control gates.
+- Directory ownership lists guard against conflicting edits.
+- Build tooling supports incremental compilation so teams avoid touching each other’s bundles.
+
+Keep phase docs updated with status and decision logs. Downstream teams rely on this documentation to plan their work without stepping on each other.

--- a/win95sim_v2/planning/phase-01-window-manager.md
+++ b/win95sim_v2/planning/phase-01-window-manager.md
@@ -1,0 +1,56 @@
+# Phase 1 – Kernel, Display, Window Manager (Multi-file Baseline)
+
+**Status:** 🚧 Planned. This phase replaces the single `index.html` monolith with a multi-file workspace that isolates the kernel, core services, shared UI primitives, and tooling. The deliverable is a reproducible build pipeline that composes these modules into a distributable bundle while keeping source authored across folders. Successful completion unblocks parallel development for Phases 2–10 because all shared contracts, linting, and build outputs are frozen here.
+
+## Objectives
+- Establish repository layout: `src/core`, `src/services`, `src/ui`, `src/apps`, `src/styles`, `src/assets`, and `tests` folders with clear ownership files.
+- Implement foundational services (`core/kernel`, `services/settings`, `services/display`, `services/window`) as individual ES modules loaded through a lightweight module loader shim.
+- Deliver CRT viewport, boot splash, and base window manager behaviour using modularized templates, stylesheets, and assets.
+- Stand up build tooling (`scripts/build.js`) that concatenates/minifies modules into the legacy `dist/index.html` artifact for backwards compatibility.
+- Publish contribution guide that documents naming conventions, dependency rules, and merge boundaries for downstream phases.
+
+## Deliverables
+1. Multi-file source tree with TypeScript/ESM configuration, lint rules, and shared tsconfig/eslint settings for deterministic builds.
+2. Automated build pipeline that outputs `dist/index.html` plus hashed asset files while preserving source maps for debugging.
+3. Window manager package under `src/apps/shell/window-manager/` exposing move/resize/min/max APIs with unit coverage.
+4. Shared UI kit in `src/ui/components/` (caption buttons, window frame, CRT viewport) referenced by the window manager and exported for later phases.
+5. `scripts/scaffolding/create-module.js` CLI that generates module folders with tests and documentation stubs to keep structure consistent.
+6. Shared testing harness (`tests/helpers/runtime.ts`) exposing `createTestRuntime()` for Node + browser tests.
+
+## Engineering Tasks
+- Scaffold repository configuration: ESLint, Prettier, TypeScript, Jest/Node test runner, Playwright baseline, commit hooks.
+- Implement module loader shim that resolves `@core`, `@services`, `@ui`, and `@apps` aliases, ensuring bundler emits deterministic chunk names.
+- Author kernel event bus, settings store, and display service as separate modules with typed contracts and exported interfaces.
+- Build window manager package with dedicated entry file and dependency graph limited to `@core` and `@services` imports.
+- Create CRT viewport layout using CSS modules/SCSS compiled into `src/styles/global.scss`.
+- Configure CI pipeline to build, lint, test, and publish artifacts, caching dependencies to support parallel developer workflows.
+
+## Concurrency Enablement
+- Define code ownership files (e.g., `OWNERS`, `CODEOWNERS`, `docs/module-boundaries.md`) per folder so later phases can work in isolation.
+- Freeze shared contracts by publishing `.d.ts` files for kernel/services and documenting change control in `docs/change-management.md`.
+- Configure lint rule that prevents cross-app imports except through approved service interfaces, reducing merge conflicts.
+- Generate feature flags for upcoming phases but keep them toggled off, enabling developers to merge without UI contention.
+
+## Testing
+- **Unit**: kernel pub/sub, settings watch/unwatch, display scaling math, window state transitions (implemented with Jest/Node in `tests/core/`).
+- **Integration** (Playwright): spawn sample windows, verify move/resize/min/max, ensure pixel mode scrollbars, assert integer scaling toggle updates data attribute, check Alt+` overlay using built bundle.
+- **Visual**: Percy/Chromatic snapshots for desktop with two sample windows (active/inactive) built from `dist/` output.
+- **Accessibility**: axe-core scan on empty desktop executed against built assets.
+- **Tooling**: Build pipeline smoke test verifying chunk manifests and integrity hashes.
+
+## Manual QA Checklist
+- Move/resize windows via mouse and keyboard (Alt+Space → Size → arrow keys) using built output from `dist/`.
+- Verify maximize respects CRT bounds and restore returns to original size.
+- Confirm minimized windows disappear (task button placeholder toggles state even if non-functional).
+- Validate scrollbars appear when resolution > viewport in pixel mode; removed in fit mode.
+- Confirm integer scaling options disabled if viewport insufficient.
+- Run scaffolding CLI to create a sample module and ensure generated files compile and pass lint/test.
+
+## Dependencies
+- None (first phase) but it establishes module boundaries that later phases must not modify without RFC.
+
+## Exit Criteria
+- All automated checks green in CI (lint, unit, integration, build verification).
+- Manual QA checklist completed with notes logged.
+- Documentation updated: architecture overview, implementation phases, testing strategy references to new capabilities, contribution guide committed.
+- `CODEOWNERS`/branch protection rules active to guard shared contracts.

--- a/win95sim_v2/planning/phase-02-vfs-explorer.md
+++ b/win95sim_v2/planning/phase-02-vfs-explorer.md
@@ -1,0 +1,55 @@
+# Phase 2 – Virtual File System & Explorer (Modular Apps)
+
+**Status:** 🚧 Planned. With the multi-file baseline in place, this phase focuses on delivering the VFS service and Explorer app as isolated packages that depend only on the Phase 1 contracts. All work lands in their dedicated folders to ensure future features can branch independently without rebasing on unrelated UI code.
+
+## Objectives
+- Deliver fully functional in-memory VFS under `src/services/vfs/` with drives, recycle bin, shortcuts, search, and import/export stubs.
+- Build Explorer shell under `src/apps/explorer/` with tree/list/details views, context menus, properties dialog, New menu, drag/drop semantics, and Find window.
+- Integrate VFS with desktop icons and window manager through published service interfaces (`@services/vfs`, `@apps/shell/taskbar`).
+- Document boundaries so later app teams (Paint, Control Panel, etc.) can reuse file APIs without modifying Explorer internals.
+
+## Deliverables
+1. `src/services/vfs/index.ts` implementation matching locked API, including special folders, watcher system, and `.d.ts` contract.
+2. Path, MIME, and icon utilities under `src/services/vfs/utils/` providing associations for Explorer.
+3. Explorer app registered with `src/services/process/` via manifest file (`src/apps/explorer/explorer.app.json`) to keep wiring declarative.
+4. Recycle bin semantics (delete, restore, empty) encapsulated in `src/services/vfs/recycle-bin.ts` with unit coverage and service events.
+5. File import/export hooks implemented through shared `src/ui/dialogs/file-transfer/` components with placeholder UI for later improvements.
+6. Storybook/Chromatic stories for Explorer components stored in `src/apps/explorer/__stories__/` to aid isolated development.
+
+## Concurrency & Integration Boundaries
+- Define ownership file `src/services/vfs/OWNERS` and `src/apps/explorer/OWNERS` so only the Explorer team touches those directories.
+- Provide mock fixtures in `tests/fixtures/vfs/` enabling other teams to simulate file operations without depending on Explorer code.
+- Export read-only TypeScript interfaces for VFS watchers to prevent downstream mutation.
+- Document extension points in `docs/explorer-integration.md` enumerating APIs safe for future phases.
+
+## Engineering Tasks
+- Implement tree data structure with metadata store and binary/blob handling for files (split into `store`, `adapters`, `search` modules).
+- Implement watchers broadcasting changes via typed events consumed by Explorer and desktop icons.
+- Implement search indexing with wildcard support and text content scanning running in a Web Worker (`src/workers/vfs-search.ts`).
+- Create Explorer UI components: tree view, list view (icons/list/details), preview/status bar, toolbar/menus backed by component library tokens.
+- Implement drag/drop between tree/list/desktop with modifier keys for move/copy/shortcut using shared drag service from Phase 1.
+- Implement file dialogs using UI toolkit for New/Rename/Delete/Properties flows, ensuring forms live under `src/ui/dialogs/`.
+- Integrate Recycle Bin UI with confirm/restore/empty actions, broadcasting telemetry events for analytics pipeline.
+
+## Testing
+- **Unit**: VFS path normalization, mkdir/write/read/move/copy/remove, shortcut resolution, recycle bin metadata, search filters using Jest suites in `tests/services/vfs/`.
+- **Integration**: Playwright scenario creating nested folders, renaming, dragging between panes, deleting/restoring; verify watchers update desktop icons via public API mocks.
+- **Visual**: Snapshots for Explorer large icons, details view, properties dialog using Storybook/Chromatic.
+- **Performance**: Automated test generating 10k files and measuring list virtualization frame time executed via `yarn test:perf` and running in CI nightly.
+
+## Manual QA Checklist
+- Context menus reflect selection (Open, Edit, Print, Copy, Paste, Create Shortcut, Delete, Properties).
+- Drag file with Ctrl (copy), Shift (move), Alt (shortcut) results in correct operation.
+- Double-click drives, special folders; ensure Control Panel/Printers open placeholders.
+- Empty Recycle Bin prompts confirmation, clears items; restore returns to original path.
+- Import local file, confirm metadata, open associated app (if available placeholder).
+- Validate that Explorer build artifacts (JS, styles, stories) are confined to `src/apps/explorer/` and tree-shake correctly.
+
+## Dependencies
+- Requires Phase 1 services and build pipeline stable; no changes to shared kernel APIs allowed without change request.
+
+## Exit Criteria
+- All unit/integration/performance tests passing.
+- Manual QA complete and logged.
+- Feature parity matrix updated for Explorer and VFS entries, including documentation of integration boundaries.
+- Dependency graph lint (`yarn lint:dep`) shows no forbidden cross-folder imports.

--- a/win95sim_v2/planning/phase-03-shell.md
+++ b/win95sim_v2/planning/phase-03-shell.md
@@ -1,0 +1,53 @@
+# Phase 3 – Desktop, Taskbar, Start Menu (Shell Packages)
+
+**Status:** 🚧 Planned. This phase delivers the desktop shell as discrete packages that sit on top of the Phase 1 kernel/services and Phase 2 VFS API. Implementation lives under `src/apps/shell/` with subfolders for desktop, taskbar, start menu, and tray. Each package exposes only public hooks so subsequent app teams can integrate without modifying shell code, allowing parallel workstreams after Phase 1.
+
+## Objectives
+- Finalize shell chrome: desktop icons, taskbar with task buttons, system tray, Start menu hierarchy, recent documents integration.
+- Implement context menus, keyboard navigation, drag/drop interactions on desktop leveraging shared UI toolkit.
+- Produce shell extension points (command registry, menu composition, tray providers) enabling independent development of utilities.
+
+## Deliverables
+1. Desktop module at `src/apps/shell/desktop/` mounting `::desktop` folder with layout persistence stored in `src/services/layout/`.
+2. Taskbar package `src/apps/shell/taskbar/` with Start button, task buttons linked to window focus/minimize state, tray clock, stub tray icons (volume/network) implemented via plugin registry.
+3. Start menu data model with Programs, Documents, Settings, Find, Help, Run, Shut Down entries defined in JSON manifest files under `src/apps/shell/start-menu/data/`.
+4. Recent documents tracking service `src/services/recent-documents/` with event hooks consumed by Start menu and Explorer.
+5. Context menu system under `src/ui/menus/` with shell-specific command adapters and declarative menu schemas.
+6. Public `ShellAPI` TypeScript definitions (`types/shell/index.d.ts`) describing extension points for future phases.
+
+## Concurrency & Integration Boundaries
+- Shell packages expose plugin interfaces via `registerShellWidget()` so Phase 4+ teams can extend Start menu or tray without editing core files.
+- Provide mocked implementations and contract tests to guarantee Start menu changes do not cascade into Explorer or utilities.
+- Document context menu command identifiers in `docs/shell-commands.md` and freeze after this phase to eliminate conflicts.
+- Introduce per-package changelog to communicate breaking changes.
+
+## Engineering Tasks
+- Implement desktop icon arrangement, multi-select, rubber-band selection, rename inline edit using shared state machines.
+- Hook taskbar buttons to window events (create, focus, minimize, close) via `@services/window` event bus.
+- Implement clock updating via `kernel.now()` ticker with localization-friendly formatting service.
+- Build Start menu navigation with keyboard accelerators, submenus, search integration using accessible menu components.
+- Implement recent documents store updated by `proc:recent:add` events and persisted via `localStorage` adapter.
+- Add system tray hover tooltips and right-click menus (volume/network stubs) with plugin registration scaffolding.
+
+## Testing
+- **Unit**: Recent documents store, Start menu data builder, taskbar state machine, menu reducer (Jest under `tests/apps/shell/`).
+- **Integration**: Playwright flows launching apps from Start, minimizing/restoring via taskbar, verifying recent docs after file opens, Start keyboard navigation (Ctrl+Esc, arrow keys, Enter) against built assets.
+- **Visual**: Snapshots for desktop idle, Start expanded, taskbar with multiple buttons, tray popover using Storybook.
+- **Accessibility**: Keyboard-only traversal tests, focus ring verification, screen reader announcements run via axe-core and NVDA smoke scripts.
+
+## Manual QA Checklist
+- Right-click desktop → View/New/Sort/Properties menu correctness.
+- Drag icons to rearrange, align to grid toggle, auto-arrange behavior.
+- Task buttons show active/inactive states, support context menu (Restore/Move/Size/Minimize/Maximize/Close).
+- Start menu closes on click outside/Esc, supports type-to-select.
+- Tray clock respects 12/24 hour toggle (if exposed) and updates each minute.
+- Validate shell plugin registration logs helpful errors when duplicate IDs are detected.
+
+## Dependencies
+- Requires Phases 1 and 2 delivered; this phase must not mutate their public contracts.
+
+## Exit Criteria
+- Automated suites passing (lint, unit, integration, visual regression).
+- Manual QA logged.
+- Feature parity matrix updated for shell components, including plugin API documentation.
+- `docs/shell-extension-guide.md` published and reviewed by downstream teams.

--- a/win95sim_v2/planning/phase-04-notepad-dialogs.md
+++ b/win95sim_v2/planning/phase-04-notepad-dialogs.md
@@ -1,0 +1,54 @@
+# Phase 4 – Dialog Framework & Notepad (Shared UI Foundation)
+
+**Status:** 🚧 Planned. Dialogs and Notepad are implemented as independent packages that consume shell APIs without modifying Phase 1–3 surfaces. The dialog framework ships from `src/ui/dialogs/` and Notepad from `src/apps/accessories/notepad/`. Teams responsible for later utilities can build on the same dialog primitives without merge conflicts.
+
+## Objectives
+- Implement reusable dialogs (Open/Save, MessageBox, Font, Color, Print) via UI toolkit with each dialog in its own folder under `src/ui/dialogs/`.
+- Build Notepad application with word wrap, find/replace, go-to line, status bar, font chooser, print integration using shared dialog primitives.
+- Integrate dialogs with Explorer and other shell features via exported service functions rather than editing their modules directly.
+- Provide scaffolding so future apps (Paint, WordPad, etc.) can register custom dialog views without touching Notepad source.
+
+## Deliverables
+1. Dialog component library with keyboard focus trapping, default button behaviour, and accessibility roles, published through `@ui/dialogs` barrel exports.
+2. File dialog supporting filters, recent directories, multi-select, thumbnail preview with adapters stored in `src/services/dialog-state/`.
+3. Notepad app registered with file associations for `.txt` and `.log` via manifest `src/apps/accessories/notepad/notepad.app.json`.
+4. Print pipeline generating text pages for Generic/Text printer and PDF output using shared print service `src/services/print/`.
+5. Updated Start menu entries (Programs → Accessories → Notepad) and desktop shortcut option defined in Start menu manifest files.
+6. Guidance document `docs/dialog-framework.md` detailing extension hooks for other teams.
+
+## Concurrency & Integration Boundaries
+- Dialog framework exposes React/Preact-agnostic primitives (pure TypeScript + templating) so multiple app teams can integrate without UI coupling.
+- Provide strict typing via `types/dialogs/*.d.ts` and lock down exports to avoid cross-editing between apps.
+- Generate reference mocks for dialogs under `tests/mocks/dialogs/` enabling other phases to stub interactions while working concurrently.
+- Document event contracts for `@services/dialog-bus` and require change control for modifications.
+
+## Engineering Tasks
+- Build dialog templates using UI toolkit menus/buttons/list views with SCSS modules co-located and compiled by bundler.
+- Implement find/replace with incremental search and wrap-around toggle using state machines stored under `src/apps/accessories/notepad/state/`.
+- Implement go-to line with validation; update status bar (Ln/Col) in real time through shared `useTextMetrics` hook.
+- Support word wrap toggle updating editor layout service; ensure preferences persist via `src/services/settings` API.
+- Integrate `@services/clipboard` for copy/paste; handle asynchronous system clipboard gracefully via fallback messaging.
+- Add Notepad-specific menu commands (Page Setup placeholder, Print, Font…) declared in JSON to keep menu definitions declarative.
+
+## Testing
+- **Unit**: Dialog filter matching, recent directory persistence, print job page layout calculations, find/replace logic executed via Jest (`tests/ui/dialogs/` and `tests/apps/notepad/`).
+- **Integration**: Playwright scenario creating text file via Explorer, editing in Notepad, using find/replace, toggling word wrap, printing to PNG and PDF printers through built assets.
+- **Visual**: Snapshots for Notepad main window, Find dialog, Font dialog, Print preview captured in Storybook.
+- **Accessibility**: Ensure dialog focus trap works; screen reader labels for controls validated with axe-core and manual NVDA/VoiceOver sweeps.
+
+## Manual QA Checklist
+- Open/save flows from both Notepad and Explorer double-click.
+- Word wrap toggle updates horizontal scrollbar availability.
+- Font dialog updates text area font family/size; persisted per session or per document as designed.
+- Print results stored in VFS spool folder with metadata and accessible via Explorer.
+- Error handling for read-only files and unsaved changes on exit (prompt to save).
+- Verify dialog manifests can be extended by creating sample plugin without editing Notepad code.
+
+## Dependencies
+- Phases 1–3 complete with frozen APIs; this phase consumes their exports only.
+
+## Exit Criteria
+- Automated suites passing (unit, integration, visual, lint).
+- Manual QA logged.
+- Documentation updated (feature matrix, testing strategy referencing dialogs, dialog framework guide).
+- Ownership files ensure future dialog additions do not conflict across teams.

--- a/win95sim_v2/planning/phase-05-navigator.md
+++ b/win95sim_v2/planning/phase-05-navigator.md
@@ -1,0 +1,55 @@
+# Phase 5 – Navigator (Web Suite Package)
+
+**Status:** 🚧 Planned. Navigator lives entirely under `src/apps/internet/navigator/` with supporting services in `src/services/network/`. The app consumes Phase 1–4 APIs only, enabling browser-focused engineers to iterate without touching shell, dialogs, or Explorer modules. Shared browser tooling (DOMPurify config, download manager hooks) is exposed via dedicated packages to prevent merge conflicts with other teams.
+
+## Objectives
+- Build the Netscape-inspired Navigator app with iframe, reader, and proxy modes using modular architecture.
+- Implement bookmarks, history, address bar, status bar, throbber animation, download manager, and view source capabilities with each subsystem in its own file tree.
+- Publish extension points for future browser add-ons (e.g., mail/news) without requiring edits to Navigator core files.
+
+## Deliverables
+1. Navigator window chrome with toolbar (Back, Forward, Stop, Reload, Home), address bar, bookmarks menu, throbber built from `src/apps/internet/navigator/components/`.
+2. Mode switching UI with persistent per-tab preference (iframe/reader/proxy) persisted via `src/services/settings` namespace `navigator.*`.
+3. iframe mode using sandboxed iframe honoring CSP/allow flags defined in `src/services/network/iframe-policy.ts`.
+4. Reader mode sanitizing pasted HTML, local files, and data URLs via DOMPurify configuration stored under `src/services/security/sanitizer.ts`.
+5. Proxy mode gated behind user configuration, prepending user-supplied proxy base URL with validation utilities in `src/services/network/proxy.ts`.
+6. Download manager saving resources to VFS and presenting progress/status using shared download service `src/services/downloads/`.
+7. View source window showing sanitized markup for accessible documents built as separate process `src/apps/tools/view-source/`.
+8. API documentation `docs/navigator-extension-guide.md` clarifying plugin hooks.
+
+## Concurrency & Integration Boundaries
+- Provide stub implementations and mocks so file associations or Start menu updates are declarative (JSON manifests) rather than manual edits.
+- Enforce dependency linting to restrict Navigator to `@core`, `@services/*`, and `@ui/*` imports; prevent cross-app couplings.
+- Establish `OWNERS` for Navigator and network services to isolate code review responsibilities.
+- Offer shared components (throbber, download list items) through `@ui/internet` barrel so other teams can reuse without editing Navigator files.
+
+## Engineering Tasks
+- Implement tab/session model (single tab initially) using state machine under `src/apps/internet/navigator/state/session.ts` with extension points for multi-tab future.
+- Integrate DOMPurify sanitization service; ensure configuration prevents script execution while retaining necessary tags.
+- Handle iframe load errors, blocked framing, and present fallback messaging with localized strings stored under `src/locales/en-US/navigator.json`.
+- Implement bookmarks store (add, remove, reorder) persisted via settings and exposed to Start menu favourites through service events.
+- Build download pipeline with fetch (same-origin/data) and fallback instructions for blocked resources; surface progress via service events.
+- Integrate with process associations for `.url` files and `http/https` protocols using manifest-driven registration.
+
+## Testing
+- **Unit**: Sanitization rules, bookmark CRUD, proxy URL validation, download manager state transitions located in `tests/apps/navigator/`.
+- **Integration**: Playwright flows loading same-origin test page in iframe mode, handling blocked iframe response, using reader mode for pasted HTML, configuring proxy (with mock server in tests), saving downloads to VFS.
+- **Visual**: Snapshots for each mode, download manager pane, view source window using Storybook or Chromatic.
+- **Security**: Tests verifying scripts/styles removed in reader mode, sandboxed iframe lacks navigation privileges, proxy validation rejects unsafe hosts.
+
+## Manual QA Checklist
+- Toggle between modes and confirm state persists per tab.
+- Bookmarks add via menu, appear in Start → Favorites (if integrated) and address dropdown.
+- Downloads produce files accessible in Explorer with correct metadata.
+- `.url` files double-click open Navigator and load target.
+- Proxy warning text clear; disable resets to safe state.
+- Confirm Navigator bundle lives exclusively under `src/apps/internet/navigator/` aside from shared services.
+
+## Dependencies
+- Phases 1–4 complete (shell, dialogs, VFS, Notepad for view source integration) with no contract changes required.
+
+## Exit Criteria
+- Automated suites passing (unit, integration, security, visual).
+- Manual QA logged.
+- Risk log updated with any outstanding Navigator items.
+- Dependency graph check verifies Navigator stays within approved import boundaries.

--- a/win95sim_v2/planning/phase-06-paint-media.md
+++ b/win95sim_v2/planning/phase-06-paint-media.md
@@ -1,0 +1,53 @@
+# Phase 6 – Paint & Media Player (Creative Suite Modules)
+
+**Status:** 🚧 Planned. Paint and Media Player are developed as separate packages under `src/apps/creative/paint/` and `src/apps/media/player/`, sharing rendering utilities from `src/services/graphics/` and audio/video abstractions from `src/services/media/`. Teams can implement these features concurrently with other app phases because they depend solely on the stabilized APIs from Phases 1–5.
+
+## Objectives
+- Deliver Paint application mirroring Win95 toolset and canvas behaviour using modularized tools, state, and rendering layers.
+- Implement Media Player supporting audio/video playback, playlists, and transport controls with reusable media service wrappers.
+- Provide shared creative utilities (color palette store, bitmap encoding helpers) for future creative apps without code duplication.
+
+## Deliverables
+1. Paint window with toolbox (pencil, brush, line, rectangle, ellipse, rounded rectangle, text, fill, spray, eraser, color picker), palette, canvas resizing, selection tools, undo/redo stack under `src/apps/creative/paint/components/`.
+2. Import/export for BMP and PNG files using shared `src/services/graphics/bitmap.ts`; optional dither filter module toggled via settings to simulate 256-color mode.
+3. Media Player window with playlist pane, playback controls (play/pause, stop, seek, volume, mute), visualization placeholder, and file associations defined via manifest `src/apps/media/player/player.app.json`.
+4. Integration with clipboard for image copy/paste within Paint and between apps using `@services/clipboard` adapters that accept binary payloads.
+5. Menu options for both apps consistent with Win95 (File/Edit/View/Options/Help variants) defined declaratively in JSON per app.
+6. Shared creative assets documented in `docs/creative-suite.md` for cross-team reuse.
+
+## Concurrency & Integration Boundaries
+- Graphics and media services expose typed interfaces (`IGraphicsContext`, `IMediaSession`) that other teams can consume without editing Paint/Media Player modules.
+- Provide stub implementations for tests in `tests/mocks/graphics/` and `tests/mocks/media/` to let parallel teams simulate behaviours.
+- Use Storybook stories for each tool/control to support design QA without impacting other feature branches.
+- Maintain dedicated `OWNERS` per app folder to guard against conflicting edits.
+
+## Engineering Tasks
+- Implement canvas rendering pipeline with offscreen buffer for undo/redo and selection manipulation stored under `src/apps/creative/paint/engine/`.
+- Implement flood fill, stroke drawing with pixel-perfect accuracy, text tool overlay using typed tool interfaces.
+- Hook dithering filter toggled via menu and integrated with Display color depth setting (consuming `@services/display`).
+- Build Media Player playlist manager (add/remove/reorder, save to VFS as `.m3u` optional) and playback logic using shared `MediaSession` wrapper.
+- Handle unsupported codecs gracefully with user messaging and fallback suggestions defined in localization files.
+- Emit telemetry events for creative/media actions to `@services/telemetry` without coupling to other apps.
+
+## Testing
+- **Unit**: Bitmap encode/decode roundtrips, undo stack operations, playlist serialization, audio/video event handling implemented via Jest in `tests/apps/creative/paint/` and `tests/apps/media/player/`.
+- **Integration**: Playwright scenario drawing, undoing, saving to VFS, reopening; verifying import/export for BMP/PNG; playing audio, seeking, volume adjustments, playlist reorder on built bundle.
+- **Visual**: Snapshots for Paint toolbox/canvas, Media Player playback state, error dialog for unsupported media captured in Storybook.
+- **Performance**: Canvas stress test drawing rapid strokes to ensure frame rate acceptable; audio buffer streaming load test via automated benchmark script.
+
+## Manual QA Checklist
+- Verify each tool functions correctly (line thickness, fill boundaries, text input editing).
+- Clipboard copy/paste from Paint to Notepad (paste as text placeholder message) and to other apps (if applicable).
+- Resize canvas with anchor options; confirm background fill.
+- Media Player handles sequential playback, loop toggle (if provided), volume slider response.
+- Drag/drop files from Explorer to Paint/Media windows opens assets.
+- Confirm Paint/Media Player assets remain isolated to their respective folders and build outputs.
+
+## Dependencies
+- Phases 1–5 complete (shell, dialogs, VFS, Navigator for image downloads if needed) with public APIs consumed only.
+
+## Exit Criteria
+- Automated suites passing (unit, integration, visual, performance, lint).
+- Manual QA logged.
+- Feature parity matrix updated for creative/media apps with documentation for shared utilities.
+- Ownership and dependency lint checks validated.

--- a/win95sim_v2/planning/phase-07-utilities-games.md
+++ b/win95sim_v2/planning/phase-07-utilities-games.md
@@ -1,0 +1,52 @@
+# Phase 7 – Utilities & Games (Parallel App Pods)
+
+**Status:** 🚧 Planned. Calculator, Minesweeper, Command Prompt, and shell utilities each live in isolated folders under `src/apps/utilities/` with shared infrastructure provided by `src/services/games/` and `src/services/cli/`. Each mini-app is assigned to a dedicated team so Phase 7 work can progress concurrently without stepping on other features.
+
+## Objectives
+- Implement Calculator, Minesweeper, Command Prompt, and system utilities (Run, Find, Shut Down, Close Program) as separate packages using shared tooling.
+- Ensure utilities integrate with shell shortcuts, Start menu, and VFS via declarative manifests and service events instead of direct file edits.
+- Provide frameworks for future games/utilities to plug into Start menu categories without modifying existing code.
+
+## Deliverables
+1. Calculator app with standard mode, memory keys, keyboard bindings, error handling for divide by zero, display overflow management located in `src/apps/utilities/calculator/`.
+2. Minesweeper app with beginner/intermediate/expert/custom board, timer, mine counter, high-score tracking within session, first-click safety under `src/apps/games/minesweeper/`.
+3. Command Prompt with DOS-like command set (dir, cd, type, copy, del, md, rd, rename, start, edit, help, echo, rem, goto, labels, pause) and batch execution under `src/apps/utilities/command-prompt/` plus shared CLI runtime `src/services/cli/`.
+4. Run dialog launching apps by ID/path/URL; Find dialog reusing Explorer search; Shut Down workflow with confirmation; Close Program list enabling end task built as shell plugins under `src/apps/shell/utilities/`.
+5. Shared scoreboard service `src/services/high-scores/` for Minesweeper and future games.
+6. Documentation `docs/utilities-extension-guide.md` describing how to register new utilities without editing existing ones.
+
+## Concurrency & Integration Boundaries
+- Provide scaffolding CLI `scripts/create-utility.js` generating new app folders with tests and manifests to prevent merge conflicts.
+- Publish TypeScript interfaces for CLI commands and game engines so teams can extend behaviour safely.
+- Set up feature flags per utility enabling partial merges while features bake in hidden mode.
+- Maintain `apps.json` manifest listing utilities consumed by Start menu; updates are append-only to avoid conflicts.
+
+## Engineering Tasks
+- Build calculator logic engine with decimal precision and memory state; integrate with UI toolkit buttons using component composition.
+- Implement Minesweeper board generation, cell state machine, recursion for zero reveals, timer control via kernel events, and high-score persistence.
+- Implement command parser and executor; integrate with VFS for file operations and with process service for launching apps using dependency injection for commands.
+- Provide scriptable interface for tests to seed Minesweeper boards and pre-populate command history using fixtures in `tests/apps/games/`.
+- Implement Run/Find/Shut Down/Close Program windows with proper menu commands and keyboard support registered through shell plugin API.
+
+## Testing
+- **Unit**: Calculator operations, command parser grammar, batch script execution, Minesweeper board validator executed via Jest per app folder.
+- **Integration**: Playwright scenario solving Minesweeper (using deterministic seed), executing command sequences (create file, edit via Notepad), launching apps via Run, terminating an app via Close Program.
+- **Visual**: Snapshots for Calculator, Minesweeper (various states), Command Prompt, Close Program dialog using Storybook.
+- **Accessibility**: Keyboard navigation for Calculator buttons, screen reader labels for Minesweeper grid, CLI contrast compliance.
+
+## Manual QA Checklist
+- Calculator memory keys (MC/MR/MS/M+/M-) behave correctly; keyboard entry matches UI input.
+- Minesweeper high scores update and display, smiley face state transitions correct.
+- Command Prompt supports piping limited built-ins (e.g., `type file.txt | more` stub) and handles invalid commands gracefully.
+- Run dialog autocompletes file paths where possible; Find dialog surfaces search results with correct double-click behaviour.
+- Shut Down displays options (Shut down, Restart, Stand by stub), triggers boot splash on restart; Close Program End Task works.
+- Confirm each utility/game remains within its folder aside from shared service updates.
+
+## Dependencies
+- Phases 1–6 complete with stable shell/dialog services; utilities consume but do not modify them.
+
+## Exit Criteria
+- Automated suites passing (unit, integration, visual, accessibility).
+- Manual QA logged.
+- Feature parity matrix updated for utilities and games and manifests merged without conflicts.
+- Dependency lint ensures utilities import only approved services.

--- a/win95sim_v2/planning/phase-08-control-panel-printers.md
+++ b/win95sim_v2/planning/phase-08-control-panel-printers.md
@@ -1,0 +1,55 @@
+# Phase 8 – Control Panel & Printers (System Configuration Suite)
+
+**Status:** 🚧 Planned. Control Panel applets and the printer subsystem are grouped into `src/apps/system/control-panel/` and `src/services/print/`. Each applet resides in its own folder with shared state managed by configuration services, allowing multiple teams to implement individual applets concurrently after Phase 1 without merge conflicts.
+
+## Objectives
+- Implement functional Control Panel applets (Display, Date/Time, Keyboard, Mouse, Sounds, Printers) with stub UI for remaining items using modular architecture.
+- Deliver printer subsystem with Generic/Text (PNG) and Virtual PDF outputs, printer queue UI, and spool folder integration, all defined within `src/services/print/` and `src/apps/system/printers/`.
+- Provide extensibility for future applets to plug into Control Panel without editing existing code.
+
+## Deliverables
+1. Control Panel hub listing applets; double-click opens dedicated windows with tabs mirroring Win95 layout using manifest-driven registration (`control-panel.manifest.json`).
+2. Display applet managing resolution, scaling mode, wallpapers, color depth simulation, CRT effects consuming `@services/display` API.
+3. Date/Time applet updating tray clock, supporting manual offset adjustments stored via `@services/settings/time` namespace.
+4. Keyboard/Mouse applets adjusting repeat rate, cursor speed (affecting in-sim behaviour only) with settings broadcast to relevant services.
+5. Sounds applet toggling schemes, previewing sounds, enabling/disabling system audio via `@services/audio`.
+6. Printers folder showing installed printers, ability to add/remove (within simulated set), view queue, pause/cancel jobs implemented in `src/apps/system/printers/`.
+7. Print service integrated with queue UI, generating output files inside VFS spool folder using pipeline defined in `src/services/print/spooler.ts`.
+8. Documentation `docs/control-panel-extension.md` outlining how to add new applets.
+
+## Concurrency & Integration Boundaries
+- Applets registered via manifest with unique IDs so new applets can be added by app teams without modifying hub source.
+- Print service exposes contract via `types/print/index.d.ts` and prohibits direct file system access; job submissions go through events.
+- Provide shared state management utilities under `src/services/config/` to prevent cross-app race conditions.
+- Introduce Playwright fixtures to mock printer hardware so other teams can run tests without conflicting spool outputs.
+
+## Engineering Tasks
+- Build Control Panel navigation (icon view, category grouping) with tooltips and descriptions using shared UI components.
+- Implement Display applet UI with live preview and apply/cancel pattern including rollback timer.
+- Integrate Display settings with `@services/display` and `@services/settings`; propagate events to desktop and shell.
+- Implement printer job state machine with progress updates, error handling, job history stored per printer.
+- Wire Notepad/Paint/Navigator print flows to queue via `@services/print` event channel; allow opening spool file from queue UI.
+- Include About dialog with license credits accessible from Control Panel or Help menu built as separate module.
+
+## Testing
+- **Unit**: Settings synchronization, printer job lifecycle transitions, wallpaper mode calculations, CRT effect toggles using Jest in `tests/apps/control-panel/` and `tests/services/print/`.
+- **Integration**: Playwright scenario changing resolution, verifying Start/desktop reflow; printing from Notepad and Paint to both printers; canceling/pausing job; toggling sound scheme and verifying playback gating using built assets.
+- **Visual**: Snapshots for each Control Panel applet, printer queue window, spool folder view captured via Storybook.
+- **Accessibility**: Tab order and focus management across tabbed dialogs; keyboard navigation of printer queue validated with axe-core.
+
+## Manual QA Checklist
+- Apply/cancel in Display applet respects pending changes and prompts for keep/discard countdown.
+- Wallpapers tile/center/stretch correctly; CRT effect intensity slider updates overlay.
+- Date/Time changes reflect immediately in tray and revert on cancel.
+- Sounds preview only after enabling audio; toggling scheme updates default beep etc.
+- Printer queue shows correct document names, copies, allows cancel/pause/resume, opens output file.
+- Confirm new applets can be added via manifest without modifying hub code.
+
+## Dependencies
+- Phases 1–7 complete with stable services; Control Panel consumes but does not mutate shared contracts.
+
+## Exit Criteria
+- Automated suites passing (unit, integration, visual, accessibility).
+- Manual QA logged.
+- Risk log updated (e.g., printer compatibility issues) and manifest validated.
+- Ownership and dependency lint checks remain green.

--- a/win95sim_v2/planning/phase-09-polish.md
+++ b/win95sim_v2/planning/phase-09-polish.md
@@ -1,0 +1,55 @@
+# Phase 9 – Polish, Themes, Screensavers (Experience Enhancements)
+
+**Status:** 🚧 Planned. All polish features live in `src/apps/system/experience/` and `src/services/theme/`, enabling UI/experience specialists to iterate without touching earlier phase code. Themes, screensavers, and audio hooks are structured as plug-ins so parallel workstreams can add assets independently after Phase 1.
+
+## Objectives
+- Add CRT effect overlay, screensavers, theme variations, system sounds, boot/shutdown sequences, BSOD easter egg, reduced-motion toggle using modular feature flags.
+- Finalize accessibility enhancements and ensure high-contrast theme parity with dedicated tokens and test coverage.
+- Provide extensible framework for future themes/screensavers to register themselves without editing core runtime files.
+
+## Deliverables
+1. CRT overlay rendered via canvas with adjustable scanline/glow/vignette intensity tied to Display settings using `src/services/theme/crt-overlay.ts`.
+2. Screensaver subsystem with idle detection, password prompt stub, bundled savers (3D Pipes, Starfield) implemented via canvas modules in `src/apps/system/experience/screensavers/`.
+3. Theme variants (Standard, Desert, High Contrast) adjusting CSS tokens defined in `src/styles/themes/` and compiled into theme bundles; high-contrast ensures compliance with WCAG contrast guidelines.
+4. System sound playback integrated with Start/taskbar/menus/window events, controlled via Sounds applet and startup/shutdown sequences through `src/services/audio/events.ts`.
+5. Boot/shutdown splash screens with optional progress animation; BSOD easter egg accessible via hidden command implemented as overlay module in `src/apps/system/experience/bsod/`.
+6. Reduced motion setting disabling animations, CRT effects, screensaver transitions exposed via `@services/accessibility`.
+7. Contributor guide `docs/experience-extensibility.md` explaining how to add new themes/screensavers.
+
+## Concurrency & Integration Boundaries
+- Theme tokens stored in JSON per theme; merging new themes only requires adding files without editing existing ones.
+- Screensavers register through manifest `screensavers.manifest.json`, enabling independent teams to contribute new savers.
+- Audio events enumerated in `types/audio-events.d.ts`; modifications require RFC to avoid conflicting changes.
+- Provide CLI `scripts/add-theme.js` for scaffolding new theme directories with tests and docs.
+
+## Engineering Tasks
+- Implement idle timer using kernel events, reset on user input, start screensaver after configurable delay stored in settings.
+- Build screensaver host window that captures pointer/keyboard to exit; integrate with test harness to force activation.
+- Update theme CSS injection to switch tokens dynamically; ensure UI components re-render when theme changes and notify active apps.
+- Implement sound event mapping and gating on permission toggle; load audio buffers lazily through shared loader.
+- Create boot/shutdown sequences triggered during initial load and via Shut Down dialog with event-driven transitions.
+- Implement BSOD overlay accessible via keyboard secret (e.g., Ctrl+Alt+Shift+B) and from Command Prompt `bsod` command using plugin registration.
+- Add telemetry instrumentation to measure theme usage and screensaver activation frequency.
+
+## Testing
+- **Unit**: Idle timer logic, theme token swapping, audio gating, manifest parsing implemented via Jest in `tests/services/theme/`.
+- **Integration**: Playwright scenario toggling themes, verifying token application; forcing screensaver activation and exit; enabling/disabling CRT effect and confirming DOM changes; verifying startup/shutdown sequences; triggering BSOD and recovery using built assets.
+- **Visual**: Snapshots for each theme, CRT on/off states, screensaver previews (static capture), boot/shutdown screens recorded through Storybook.
+- **Accessibility**: Ensure reduced motion disables animations and CRT; high-contrast passes axe-core checks and manual contrast verification.
+
+## Manual QA Checklist
+- Validate screensaver delay configurable, exit on mouse/keyboard, optional password prompt stub functioning.
+- Theme switching persists during session and across new windows; high-contrast ensures legible text.
+- Sounds respond to events (menu open, error, minimize) when enabled, remain silent when disabled.
+- Boot/shutdown sequences play correct audio/visual; BSOD accessible and recovers gracefully.
+- Reduced motion toggle disables animations and prevents new ones from starting.
+- Confirm new themes/screensavers can be added by dropping manifest entries without editing existing files.
+
+## Dependencies
+- Phases 1–8 complete; this phase consumes their services only.
+
+## Exit Criteria
+- Automated suites passing (unit, integration, visual, accessibility).
+- Manual QA logged.
+- Documentation updated (theme descriptions, accessibility notes, extensibility guide).
+- Dependency lint and ownership rules validated for new experience modules.

--- a/win95sim_v2/planning/phase-10-packaging.md
+++ b/win95sim_v2/planning/phase-10-packaging.md
@@ -1,0 +1,48 @@
+# Phase 10 – Packaging & Release (Multi-file Source → Single-file Output)
+
+**Status:** 🚧 Planned. This phase finalizes the release tooling that consumes the multi-file workspace and emits the legacy single-file distribution. Packaging scripts live under `tools/release/` so release engineers can iterate independently once earlier phases stabilize.
+
+## Objectives
+- Produce final single-file HTML build with minified assets, license banner, and integrity metadata sourced from modular directories.
+- Validate cross-browser compatibility and finalize release documentation, ensuring reproducible builds from CI or local environments.
+- Establish long-term maintenance workflows (hotfix branches, version bumps) that respect module boundaries introduced in Phase 1.
+
+## Deliverables
+1. Build pipeline (Node script or similar) that stitches modules, minifies JS/CSS, compresses assets, and inlines base64 resources into final `dist/win95sim.html` while preserving source maps.
+2. License banner appended to output including project license and third-party attributions (DOMPurify, jsPDF, fflate if used, asset authors) pulled from `docs/licenses.json`.
+3. Hash manifest (SHA-256) and file size report for release notes plus optional zipped distributions, stored in `dist/manifest.json`.
+4. About dialog updated with version, API contract version, license details, credits via generated data file `src/apps/system/about/about.data.json`.
+5. Release checklist covering QA sign-off, regression status, browser matrix results maintained in `docs/release-checklist.md`.
+6. Deployment instructions for static hosting (GitHub Pages, Netlify) and npm package distribution documented in `docs/deployment.md`.
+7. Automation to tag releases, update changelog, and create GitHub releases using GitHub Actions workflow in `.github/workflows/release.yml`.
+
+## Engineering Tasks
+- Implement build script reading modular source and producing single file according to architecture blueprint, leveraging Rollup/ESBuild pipeline configured in `tools/release/build.ts`.
+- Integrate HTML minifier, CSS/JS minifiers, base64 compression pipeline; ensure deterministic chunk ordering for consistent diffs.
+- Verify third-party libraries included exactly once with proper wrappers; fail build if duplicates detected.
+- Generate integrity hash, file size metrics, optional Brotli/gzip size estimates and embed them into release notes template.
+- Automate license text injection and About dialog generation from data file using script `tools/release/generate-about.ts`.
+- Prepare release notes template referencing feature parity matrix and risk log updates; integrate with PR automation.
+- Set up CI job to build, run regression tests, and attach artifacts for manual review.
+
+## Testing
+- **Unit**: Build script modules (asset bundler, manifest generator) with sample inputs executed via Jest under `tests/tools/release/`.
+- **Integration**: Playwright smoke test running against minified artifact to ensure identical behaviour to development build; cross-browser run (Chromium, Firefox, WebKit, Safari manual) verifying no regressions.
+- **Visual**: Snapshot diffs verifying minified build identical to reference using `yarn test:visual --release`.
+- **Performance**: Measure initial load time, ensure within acceptable envelope (<3s on reference hardware) and document results in release notes.
+- **Security**: Verify Subresource Integrity hashes and Content Security Policy meta tags applied correctly.
+
+## Manual QA Checklist
+- Load final file locally in Chrome/Firefox/Safari; ensure no console errors, all apps launch, screensavers operate, sound toggle works.
+- Validate About dialog lists all licenses, version numbers, API contract version.
+- Run full regression checklist from earlier phases; ensure no outstanding high-severity issues.
+- Confirm export/import (if implemented) works with minified build.
+- Verify release automation publishes expected assets and tags when run in dry-run mode.
+
+## Dependencies
+- Phases 1–9 complete with stable module contracts and documentation.
+
+## Exit Criteria
+- Final build artifact produced and stored in release directory with accompanying manifest and hashes.
+- All automated and manual checks green; CI release pipeline passes without intervention.
+- Release notes approved; project ready for distribution with signed tag and changelog entry.

--- a/win95sim_v2/planning/qa-checklists/phase-01.md
+++ b/win95sim_v2/planning/qa-checklists/phase-01.md
@@ -1,0 +1,8 @@
+# QA Checklist – Phase 1
+- [ ] Windows can be created, moved, resized via mouse.
+- [ ] Alt+Space opens system menu; keyboard Size/Move operations function.
+- [ ] Maximize respects CRT bounds; restore returns to original dimensions.
+- [ ] Pixel mode shows scrollbars when resolution exceeds viewport; fit/integer hide them.
+- [ ] Alt+` task switcher lists windows and changes focus.
+- [ ] Axe-core scan yields no critical accessibility issues on base desktop.
+- [ ] `yarn build` produces `dist/win95sim.html` without module resolution warnings.

--- a/win95sim_v2/planning/qa-checklists/phase-02.md
+++ b/win95sim_v2/planning/qa-checklists/phase-02.md
@@ -1,0 +1,15 @@
+# QA Checklist – Phase 2
+
+_Current functionality (Phase 2 initial drop):_
+- [x] Create folders/files via Explorer toolbar.
+- [x] Delete removes items from the active folder.
+- [x] Search returns name matches within the selected scope (no content search yet).
+
+_Outstanding for future iterations:_
+- [ ] Rename inline (F2) updates VFS metadata.
+- [ ] Drag/drop with Ctrl=Copy, Shift=Move, Alt=Shortcut behaves correctly.
+- [ ] Delete sends items to Recycle Bin; Restore returns to original path.
+- [ ] Empty Recycle Bin clears contents after confirmation.
+- [ ] Search finds files by name and content; double-click result opens location.
+- [ ] Import local file via drag/drop or dialog.
+- [ ] Dependency lint confirms Explorer/VFS code only imports from `@core`, `@services`, `@ui`, or local modules.

--- a/win95sim_v2/planning/qa-checklists/phase-03.md
+++ b/win95sim_v2/planning/qa-checklists/phase-03.md
@@ -1,0 +1,8 @@
+# QA Checklist – Phase 3
+- [ ] Desktop icons align to grid, support multi-select, and rename inline.
+- [ ] Start menu opens via mouse, keyboard (Ctrl+Esc), and closes with Esc/click outside.
+- [ ] Start → Programs launches registered app; taskbar button appears.
+- [ ] Taskbar buttons toggle minimized/restored state and show context menu.
+- [ ] Tray clock updates each minute; tooltip displays full date/time.
+- [ ] Recent Documents shows files opened in current session.
+- [ ] Verify shell package ownership (`src/apps/shell/**`) enforced by CODEOWNERS and dependency lint.

--- a/win95sim_v2/planning/qa-checklists/phase-04.md
+++ b/win95sim_v2/planning/qa-checklists/phase-04.md
@@ -1,0 +1,9 @@
+# QA Checklist – Phase 4
+- [ ] Open/Save dialogs respect filters and remember last directory.
+- [ ] Notepad find/replace works for forward/backward search with wrap toggle.
+- [ ] Go To Line jumps accurately; invalid input triggers error dialog.
+- [ ] Word Wrap toggle affects horizontal scrollbar and status bar visibility.
+- [ ] Font dialog updates text area font and persists within session.
+- [ ] Print to Generic/Text produces PNG file in spool; Print to PDF produces readable PDF.
+- [ ] Unsaved changes prompt when closing Notepad or shutting down.
+- [ ] Dialog components import via `@ui/dialogs` barrel only; dependency lint passes.

--- a/win95sim_v2/planning/qa-checklists/phase-05.md
+++ b/win95sim_v2/planning/qa-checklists/phase-05.md
@@ -1,0 +1,9 @@
+# QA Checklist – Phase 5
+- [ ] Navigator loads same-origin demo page in iframe mode without console errors.
+- [ ] Blocked iframe shows explanatory message and suggests reader/proxy fallback.
+- [ ] Reader mode sanitizes script tags and inline event handlers.
+- [ ] Proxy mode requires explicit URL configuration and warns about privacy.
+- [ ] Bookmarks can be added/removed; selecting bookmark loads page.
+- [ ] Downloads save to VFS and appear in Explorer with metadata.
+- [ ] View Source shows sanitized HTML and allows copy.
+- [ ] Dependency lint confirms Navigator only imports approved network/UI services.

--- a/win95sim_v2/planning/qa-checklists/phase-06.md
+++ b/win95sim_v2/planning/qa-checklists/phase-06.md
@@ -1,0 +1,9 @@
+# QA Checklist – Phase 6
+- [ ] Each Paint tool renders expected output; undo/redo works for 10+ steps.
+- [ ] Fill tool respects enclosed boundaries; color picker selects from canvas.
+- [ ] Import BMP/PNG loads correctly; export reopens identically.
+- [ ] Clipboard copy/paste interacts with other apps (paste into Notepad shows placeholder message).
+- [ ] Media Player plays audio and video, updates timeline, supports seek, mute, volume.
+- [ ] Unsupported media shows friendly error and does not crash app.
+- [ ] Playlist add/remove/reorder persists during session.
+- [ ] Graphics/media packages import shared services only (`@services/graphics`, `@services/media`) per lint report.

--- a/win95sim_v2/planning/qa-checklists/phase-07.md
+++ b/win95sim_v2/planning/qa-checklists/phase-07.md
@@ -1,0 +1,9 @@
+# QA Checklist – Phase 7
+- [ ] Calculator handles basic operations, decimals, negative numbers, memory keys.
+- [ ] Minesweeper first click never hits a mine; timer and counter work; win/lose dialogs appear.
+- [ ] High scores update when beating best time and persist for session.
+- [ ] Command Prompt executes dir/cd/type/copy/del/md/rd/rename/start/edit/help.
+- [ ] Batch file with labels/goto executes; invalid command shows error message.
+- [ ] Run dialog launches apps by name and file path; Find dialog returns search results.
+- [ ] Shut Down flow displays options and triggers boot splash when restarting; Close Program can end hung app.
+- [ ] CODEOWNERS enforces per-utility ownership; dependency lint confirms utilities/games import only allowed services.

--- a/win95sim_v2/planning/qa-checklists/phase-08.md
+++ b/win95sim_v2/planning/qa-checklists/phase-08.md
@@ -1,0 +1,9 @@
+# QA Checklist – Phase 8
+- [ ] Display applet changes resolution/scale/wallpaper/color depth and applies correctly with confirmation prompt.
+- [ ] CRT effect intensity slider updates overlay live; reduced mode resets.
+- [ ] Date/Time adjustments reflect in tray clock; cancel reverts.
+- [ ] Keyboard/Mouse sliders affect key repeat and pointer speed within apps.
+- [ ] Sounds preview plays only when enabled; toggling scheme updates event sounds.
+- [ ] Printers folder lists Generic/Text and Virtual PDF; add/remove actions work.
+- [ ] Print jobs show in queue with progress; pause/resume/cancel behave; output files open in Explorer.
+- [ ] Control Panel applets register via manifest only; lint confirms no direct edits to hub module.

--- a/win95sim_v2/planning/qa-checklists/phase-09.md
+++ b/win95sim_v2/planning/qa-checklists/phase-09.md
@@ -1,0 +1,8 @@
+# QA Checklist – Phase 9
+- [ ] Screensaver activates after idle timeout, exits on input, optional password prompt appears.
+- [ ] CRT effect toggle and intensity update visuals; reduced motion disables effect.
+- [ ] Theme switching updates entire UI instantly; high-contrast meets readability requirements.
+- [ ] System sounds fire for menu open, error, minimize, startup/shutdown when enabled; silent when disabled.
+- [ ] Boot/shutdown sequences display and play audio appropriately.
+- [ ] BSOD easter egg triggers via shortcut/command and recovers with Enter.
+- [ ] Theme/screensaver manifests validate via `yarn lint:manifests`; no manual edits required to core runtime.

--- a/win95sim_v2/planning/qa-checklists/phase-10.md
+++ b/win95sim_v2/planning/qa-checklists/phase-10.md
@@ -1,0 +1,9 @@
+# QA Checklist – Phase 10
+- [ ] Build script produces single HTML file with expected sections (fonts, CSS, templates, modules, boot).
+- [ ] License banner lists project and third-party licenses.
+- [ ] SHA-256 hash and size recorded in release notes.
+- [ ] Minified build passes Playwright smoke suite in Chromium, Firefox, WebKit.
+- [ ] Manual run in Chrome/Firefox/Safari shows no console errors.
+- [ ] About dialog displays version, API contract version, credits.
+- [ ] Regression checklist from prior phases executed without failures.
+- [ ] GitHub Actions release workflow completes dry-run successfully and attaches artifacts.

--- a/win95sim_v2/planning/risk-log.md
+++ b/win95sim_v2/planning/risk-log.md
@@ -1,0 +1,17 @@
+# Risk Log
+
+| ID | Risk | Phase Impact | Likelihood | Severity | Mitigation | Owner | Status |
+|----|------|--------------|------------|----------|------------|-------|--------|
+| R1 | Navigator blocked by CSP/X-Frame-Options prevents iframe mode | Phase 5 | High | Medium | Provide reader/proxy modes with clear messaging; unit tests for sanitized content; document limitations. | Engineering | Open |
+| R2 | Playwright visual diffs flaky due to CRT effects and animation jitter | Phase 1+ | Medium | Medium | Disable animations during capture; use deterministic seeds; adjust thresholds; provide Storybook baselines per package. | QA | Open |
+| R3 | Bundled `dist/win95sim.html` plus assets exceed target download size (>10 MB) | Phase 10 | Medium | High | Compress assets, lazy-load base64 data, review audio duration, optimize sprite sheets, monitor bundle analyzer in CI. | Engineering | Open |
+| R4 | Performance degradation with large VFS directories (10k files) | Phase 2 | Medium | High | Implement list virtualization; benchmark via automated performance tests; optimize DOM updates. | Engineering | Open |
+| R5 | Accessibility regressions (keyboard focus, high contrast) introduced late | Phase 3+ | Low | High | Maintain accessibility checks in automation; include manual keyboard tours in QA checklists. | QA | Open |
+| R6 | Printer PDF generation incorrect or incompatible with readers | Phase 8 | Medium | Medium | Create unit tests validating jsPDF output metadata; test across multiple PDF viewers; provide fallback PNG export. | Engineering | Open |
+| R7 | Sounds blocked by browser autoplay policies | Phase 9 | Medium | Low | Defer audio initialization until first user gesture; provide toggle in Sounds control panel; add tests verifying gating. | Engineering | Open |
+| R8 | Minesweeper/randomized features create non-deterministic tests | Phase 7 | Medium | Medium | Inject deterministic seeds during automated tests; expose seed override in `__win95TestApi`. | QA | Open |
+| R9 | Proxy mode misuse introduces privacy concerns | Phase 5 | Low | Medium | Display explicit warnings; disable by default; allow user-supplied endpoint only via settings. | Product | Open |
+| R10 | Build pipeline fails to inline third-party licenses | Phase 10 | Low | Medium | Add CI check verifying license text presence; unit test for About dialog content; enforce `docs/licenses.json` update gate. | Engineering | Open |
+| R11 | Interim Explorer lacks recycle bin/context menu parity causing user confusion | Phase 2 | Medium | Low | Document interim limitations, gate destructive actions behind follow-up work, prioritize recycle bin/context menu backlog items in next iteration. | Product | Open |
+| R12 | Cross-team changes break module boundaries causing merge conflicts | Phase 1+ | Medium | Medium | Enforce dependency lint rules, require CODEOWNERS approval per package, run change detection scripts in CI. | Engineering | Open |
+| R13 | Shared type definitions drift from implementation causing runtime mismatches | Phase 1+ | Medium | Medium | Generate `.d.ts` files from source in CI, run API snapshot tests, publish versioned contracts. | Engineering | Open |

--- a/win95sim_v2/planning/testing-strategy.md
+++ b/win95sim_v2/planning/testing-strategy.md
@@ -1,0 +1,67 @@
+# Testing Strategy (Multi-file Workspace)
+
+## Goals
+- Provide confidence that each phase delivers stable, regression-safe functionality across the multi-file source tree.
+- Balance fast deterministic tests with high-value browser automation and visual checks while enabling teams to run suites in parallel.
+- Ensure coverage of functional, visual, accessibility, performance, and packaging aspects from source modules through the bundled single-file output.
+
+## Test Layers
+1. **Unit Tests (Vitest/Jest + jsdom)**
+   - Target pure logic modules: `src/core/*`, `src/services/*`, `src/ui/*`, `src/apps/*` state machines, build scripts under `tools/`.
+   - Execute via shared Jest/Vitest configuration located in `tests/config/` with path aliases matching source folders.
+   - Tests live beside modules (`*.spec.ts`) and in central suites (`tests/services/*`) to allow teams to run focused watch mode.
+   - Fast feedback (<2 minutes) suitable for pre-commit hooks and CI thanks to incremental caching.
+
+2. **Integration Tests (Playwright)**
+   - Launch both the dev server bundle (`yarn dev`) and the final packaged `dist/win95sim.html` in Chromium, Firefox, WebKit (headless in CI, headed locally when debugging).
+   - Use `window.__win95TestApi` from Phase 1 plus new helpers exported by `tests/helpers/runtime.ts` to orchestrate setup/reset and inspect VFS/task/window state.
+   - Automate user journeys for each phase, tagged by milestone so suites can run incrementally and in parallel shards.
+   - Capture DOM assertions, ensure taskbar/window states, validate VFS changes, confirm dialogs across modular builds.
+
+3. **Visual Regression Tests**
+   - Playwright screenshot comparisons with per-phase baselines (desktop idle, Start menu, Explorer views, Notepad, Navigator modes, Paint, Control Panel, screensavers, themes) stored under `tests/visual-baselines/`.
+   - Threshold tuned for CRT effects and dithering noise; run in deterministic mode (disable animations during capture) via shared helper.
+   - Storybook/Chromatic integration supplements Playwright for component-level coverage per package.
+
+4. **Performance & Reliability Tests**
+   - Synthetic benchmarks creating thousands of files to confirm list virtualization throughput executed with Node workers under `tests/perf/`.
+   - Window drag/resize responsiveness measurement via Playwright performance APIs for both dev and packaged builds.
+   - Memory usage checks ensuring idle footprint stays below target (documented for manual monitoring) with automated regression thresholds.
+
+5. **Accessibility & Interaction Audits**
+   - Automated checks using axe-core via Playwright for semantic issues.
+   - Keyboard-only scripted tests verifying focus traversal and accelerator handling.
+   - Manual checklist for screen reader hints, high-contrast, reduced motion documented per package; issues logged with owning team.
+
+6. **Manual Exploratory Testing**
+   - Phase-specific QA checklists stored in `planning/qa-checklists/` (duplicated for multi-file release) executed against packaged build.
+   - Regression tours covering app launch/close, drag-drop combos, printer queue operations, error dialogs with focus on cross-package integration points.
+
+7. **Tooling & Packaging Validation**
+   - Release pipeline smoke tests confirming `tools/release/build.ts` produces deterministic artifacts.
+   - Integrity checks verifying manifest hashes, license injection, and module boundary lint before publishing.
+
+## Tooling
+- **Unit**: Vitest/Jest with ts-node/ESBuild transformers, jsdom environment.
+- **Browser**: Playwright test runner with per-browser matrix and parallel shards.
+- **Visual**: Playwright snapshot feature plus Chromatic/Storybook for component coverage.
+- **Accessibility**: axe-core integration and NVDA/VoiceOver manual sweeps scheduled per release.
+- **CI**: GitHub Actions or similar running all layers on each push/PR; artifact upload for screenshots, logs, and packaged builds; caching node_modules to speed pipelines.
+- **Static Analysis**: Dependency-cruiser/ESLint rules preventing cross-package imports outside approved boundaries.
+
+## Test Data & Fixtures
+- Synthetic VFS seeds (JSON) representing large directories, sample documents, images, audio, video, HTML snippets.
+- Local HTML pages replicating iframe-blocked headers for Navigator fallback tests.
+- Scriptable Minesweeper board seeds to validate deterministic win/loss flows.
+
+## Maintenance Practices
+- Tests added in the same phase as features; each package owns its suites and must update them before merging.
+- Snapshots reviewed and updated only when visual changes are intentional and approved by design.
+- Document all known flaky tests in risk log with mitigation plan and responsible package.
+- Keep automation harness up to date with new command IDs and service events; publish helper utilities in `tests/helpers/` instead of duplicating logic.
+- Enforce branch protections requiring lint + unit + integration + packaging jobs before merge to maintain compatibility across parallel teams.
+
+## Reporting
+- CI publishes test dashboard summarizing unit/integration/visual results.
+- Manual QA outcomes logged alongside phase documents with date, tester, and notes.
+- Known issues tracked in risk log with severity and target resolution phase.

--- a/win95sim_v2/references/feature-parity-matrix.csv
+++ b/win95sim_v2/references/feature-parity-matrix.csv
@@ -1,0 +1,14 @@
+phase,module,win95-feature,status,notes
+01,shell/desktop,Desktop icons,planned,Requires filesystem stubs to surface shortcuts
+01,features/window-chrome,Resizable overlapping windows,planned,Implements via registry + CSS tokens
+01,core/runtime,Multitasking scheduler,planned,Stub process service for now
+02,apps/explorer,Explorer tree + details view,planned,Depends on filesystem service
+03,apps/command-shell,MS-DOS prompt emulation,planned,Interop with process service events
+04,features/dialogs,Common dialog framework,planned,Reuses window chrome API
+04,apps/notepad,Plain-text editor with menu accelerators,planned,Consumes dialogs + filesystem write access
+05,apps/navigator,IE-like browsing experience,planned,Requires networking service and sandboxed rendering
+06,apps/paint,Bitmap editing tools,planned,Uses media service for palette handling
+07,apps/games,Classic games suite,planned,Leverages shared window chrome + audio assets
+08,apps/control-panel,Category-based settings,planned,Needs device service API
+09,ui/accessibility,High-contrast + screen reader support,planned,Expands CSS tokens and focus handling
+10,tools/release,Offline package + checksum,planned,Bundles dist/ for distribution

--- a/win95sim_v2/references/ui-guidelines.md
+++ b/win95sim_v2/references/ui-guidelines.md
@@ -1,0 +1,44 @@
+# UI Guidelines
+
+These guidelines keep the Win95 aesthetic authentic while leveraging the new modular UI library.
+
+## Layout & grid
+- Use the 8px base grid for spacing. Components align to multiples of 4px when mimicking Win95 quirks.
+- Windows default to 8px padding inside content regions.
+- Taskbar height: 28px. Start button width: 90px.
+
+## Typography
+- Primary font stack defined in `ui/tokens.css` (`--win95-font-ui`).
+- Heading sizes:
+  - Title bar: 11px bold
+  - Menu items: 10px
+  - Body copy: 10px
+- Avoid custom fonts unless cleared with design.
+
+## Color system
+- Consume CSS variables from `ui/tokens.css`.
+- For high contrast mode (Phase 09), rely on semantic tokens: `--color-surface`, `--color-text`, etc. These map to Win95 defaults initially.
+- Do not hard-code hex values in component styles.
+
+## Components
+- **Buttons** – Use beveled borders with inset/outset shadows defined by mixins in `ui/components/button.css`.
+- **Menus** – Provide keyboard navigation (arrow keys, Alt shortcuts) and use ARIA roles (`menu`, `menuitem`).
+- **Windows** – Title bar supports double-click to maximize/restore. Provide system menu button on the left.
+- **Dialogs** – Offer primary/secondary buttons with default focus indicated by dotted outline.
+
+## Motion & interactions
+- Keep animations subtle (`≤ 150ms`). Provide `prefers-reduced-motion` fallbacks that disable transitions.
+- Drag & drop should use cursor hints consistent with Win95 (move, copy, no-drop).
+
+## Accessibility
+- Every interactive control must have a keyboard path and visible focus state.
+- Provide screen reader labels for icons. If decorative, mark with `aria-hidden="true"`.
+- Ensure contrast ratios meet WCAG AA in both normal and high-contrast themes.
+
+## Responsive considerations
+- While optimized for desktop, layouts should gracefully adapt down to 768px width.
+- Taskbar may collapse into a compact mode controlled by a feature flag (Phase 01 backlog item).
+
+## Documentation & review
+- Update this file when introducing new component patterns.
+- Include screenshots or GIFs in PR descriptions for visual changes (link to assets in `references/visual-diffs/` once created).

--- a/win95sim_v2/tests/phase01-window-manager.test.js
+++ b/win95sim_v2/tests/phase01-window-manager.test.js
@@ -1,0 +1,16 @@
+const test = require('node:test');
+
+// Phase 01 will implement the window manager, shell boot, and module registry.
+// The tests below outline the expectations teams should satisfy while building the feature set.
+
+test('window manager exposes create/move/resize lifecycle', (t) => {
+  t.todo('implement WindowManager contract once core/runtime/windows exists');
+});
+
+test('module registry registers shell/taskbar without collisions', (t) => {
+  t.todo('assert registry rejects duplicate ids when implemented');
+});
+
+test('shell session boots and emits session:ready', (t) => {
+  t.todo('simulate session boot using Phase 01 bootloader');
+});

--- a/win95sim_v2/tests/phase02-filesystem.test.js
+++ b/win95sim_v2/tests/phase02-filesystem.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+
+// Placeholder suite for the Virtual File System Explorer deliverables.
+
+test('filesystem service returns directory listings', (t) => {
+  t.todo('mock in-memory filesystem in Phase 02 implementation');
+});
+
+test('explorer app renders tree and details panes', (t) => {
+  t.todo('mount explorer UI once features are available');
+});

--- a/win95sim_v2/tests/phase03-shell.test.js
+++ b/win95sim_v2/tests/phase03-shell.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+
+// Placeholder suite for the command shell and scripting runtime.
+
+test('command shell executes built-in commands', (t) => {
+  t.todo('wire to process service once Phase 03 begins');
+});
+
+test('scripting engine exposes automation API', (t) => {
+  t.todo('assert compatibility with legacy macros');
+});

--- a/win95sim_v2/tests/phase04-notepad.test.js
+++ b/win95sim_v2/tests/phase04-notepad.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+
+// Placeholder suite for Notepad and dialog framework work.
+
+test('notepad saves text to filesystem service', (t) => {
+  t.todo('integrate with write API from Phase 02');
+});
+
+test('common dialogs emit primary/secondary actions', (t) => {
+  t.todo('assert keyboard shortcuts once dialogs implemented');
+});

--- a/win95sim_v2/tests/phase05-navigator.test.js
+++ b/win95sim_v2/tests/phase05-navigator.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+
+// Placeholder suite for the Navigator app and networking stack.
+
+test('navigator loads page manifests through networking service', (t) => {
+  t.todo('mock network requests once service is implemented');
+});
+
+test('navigator respects security sandbox policies', (t) => {
+  t.todo('verify disallowed protocols are rejected');
+});

--- a/win95sim_v2/tests/phase06-paint.test.js
+++ b/win95sim_v2/tests/phase06-paint.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+
+// Placeholder suite for the Paint and media utilities.
+
+test('paint supports basic drawing tools', (t) => {
+  t.todo('assert bitmap buffer updates once implemented');
+});
+
+test('media service loads palette data', (t) => {
+  t.todo('mock palette fetch and verify caching');
+});

--- a/win95sim_v2/tests/phase07-games.test.js
+++ b/win95sim_v2/tests/phase07-games.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+
+// Placeholder suite for games and utility applications.
+
+test('minesweeper enforces deterministic random seeds', (t) => {
+  t.todo('expose seedable RNG in utilities package');
+});
+
+test('solitaire tracks score and undo history', (t) => {
+  t.todo('implement scoring rules when cards engine is ready');
+});

--- a/win95sim_v2/tests/phase08-control-panel.test.js
+++ b/win95sim_v2/tests/phase08-control-panel.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+
+// Placeholder suite for Control Panel and device management features.
+
+test('control panel loads applets dynamically', (t) => {
+  t.todo('assert module manifests register correctly');
+});
+
+test('printer manager queues jobs', (t) => {
+  t.todo('simulate device service once available');
+});

--- a/win95sim_v2/tests/phase09-polish.test.js
+++ b/win95sim_v2/tests/phase09-polish.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+
+// Placeholder suite for accessibility, localization, and performance polish.
+
+test('high contrast theme switches CSS tokens', (t) => {
+  t.todo('assert UI updates when localization service changes theme');
+});
+
+test('localization service loads language packs', (t) => {
+  t.todo('mock translation catalogs and verify fallbacks');
+});

--- a/win95sim_v2/tests/phase10-packaging.test.js
+++ b/win95sim_v2/tests/phase10-packaging.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+
+// Placeholder suite for packaging, telemetry opt-in, and release automation.
+
+test('build pipeline emits dist/ bundle manifest', (t) => {
+  t.todo('assert manifest includes hashes once tooling exists');
+});
+
+test('telemetry service respects opt-in setting', (t) => {
+  t.todo('mock user preference store in Phase 10');
+});


### PR DESCRIPTION
## Summary
- add repository-level guidance for win95sim_v2 including AGENTS, README, and planning overview
- document the multi-file architecture, module APIs, asset governance, and roadmap updates for the modular platform
- seed references and placeholder phase-aligned Node test suites so future work can implement features in parallel

## Testing
- not run (documentation and scaffolding only)

------
https://chatgpt.com/codex/tasks/task_e_68f64cc72afc832996e99d19b81e8777