### PR TITLE
Add virtual file system service and Explorer app

### DIFF
--- a/win95sim_v2/docs/explorer-integration.md
+++ b/win95sim_v2/docs/explorer-integration.md
@@ -1,0 +1,44 @@
+# Explorer Integration Notes
+
+Phase 02 introduces a modular Virtual File System (VFS) service and the Explorer
+application. The notes below summarise extension points and expectations for
+teams integrating with the new modules.
+
+## Services
+- **Module id:** `services/vfs`
+- **Factory:** `createVfsService(options?: CreateVfsServiceOptions)`
+- **Surface:**
+  - CRUD helpers (`writeFile`, `makeDirectory`, `remove`, `move`).
+  - Watchers via `watch(path, handler)` returning an unsubscribe function.
+  - Text-aware search (`search(query, { includeContent?: boolean })`).
+  - Recycle bin APIs exposed through `service.recycleBin` with `list`,
+    `restore`, and `empty` helpers.
+  - Shortcut resolution using `resolveShortcut(path)`.
+  - Event bus (`service.bus`) emitting `vfs:*` events for cross-service
+    listeners.
+
+Consumers should prefer the high-level API instead of mutating internal state.
+Paths are normalised (`C:/Folder/File.txt`) and drives are case insensitive.
+
+## Explorer app
+- Declared via `src/apps/explorer/explorer.app.json` so the process service can
+  discover and spawn Explorer windows.
+- Runtime entry point `createExplorerApp({ vfs, startPath })` renders tree and
+  details panes. The app listens to VFS watchers so desktop icons and other apps
+  can share the same service instance without refreshing the view manually.
+- Breadcrumb navigation emits `setPath` calls that downstream tooling can hook
+  into for automation or testing.
+
+## Fixtures
+`tests/fixtures/vfs/sampleTree.js` exports a helper that returns a seed array
+compatible with `createVfsService({ seed })`. Other phases can reuse the fixture
+for deterministic test data without touching Explorer internals.
+
+## Compatibility
+- The VFS service keeps string-based path APIs to align with the single-file
+  simulator. Any new binary/file abstractions should be additive.
+- Watch events follow the pattern `{ type, node, previousPath? }` and mirror
+  Windows Explorer semantics (`created`, `updated`, `moved`, `deleted`,
+  `restored`).
+
+Please update this document when introducing new public hooks or behaviours.

--- a/win95sim_v2/src/apps/explorer/OWNERS
+++ b/win95sim_v2/src/apps/explorer/OWNERS
@@ -1,0 +1,1 @@
+phase-02-team

--- a/win95sim_v2/src/apps/explorer/explorer.app.json
+++ b/win95sim_v2/src/apps/explorer/explorer.app.json
@@ -1,0 +1,14 @@
+{
+  "id": "apps/explorer",
+  "name": "Explorer",
+  "entry": "./index.ts",
+  "icon": "./icons/explorer.png",
+  "permissions": ["filesystem.read", "filesystem.write"],
+  "windows": [
+    {
+      "id": "explorer-main",
+      "title": "Windows Explorer",
+      "size": { "width": 640, "height": 480 }
+    }
+  ]
+}

--- a/win95sim_v2/src/apps/explorer/index.ts
+++ b/win95sim_v2/src/apps/explorer/index.ts
@@ -1,0 +1,259 @@
+import type { VfsNode, VfsService, VfsWatchEvent } from '@services/vfs';
+
+interface ExplorerTreeNode {
+  path: string;
+  name: string;
+  children: ExplorerTreeNode[];
+}
+
+export interface ExplorerOptions {
+  vfs: VfsService;
+  startPath?: string;
+}
+
+export interface ExplorerInstance {
+  mount(host: HTMLElement): void;
+  destroy(): void;
+  setPath(path: string): Promise<void>;
+  getCurrentPath(): string;
+}
+
+export function createExplorerApp(options: ExplorerOptions): ExplorerInstance {
+  const vfs = options.vfs;
+  let currentPath = options.startPath ?? 'C:/';
+  let container: HTMLElement | null = null;
+  let treePane: HTMLElement | null = null;
+  let detailsPane: HTMLElement | null = null;
+  let breadcrumbs: HTMLElement | null = null;
+  let detailWatcher: (() => void) | null = null;
+  const teardown: Array<() => void> = [];
+  let treeRenderToken = 0;
+
+  function normalize(path: string): string {
+    return path.replace(/\\/g, '/');
+  }
+
+  function clearHost() {
+    if (!container) {
+      return;
+    }
+    container.innerHTML = '';
+    treePane = null;
+    detailsPane = null;
+    breadcrumbs = null;
+  }
+
+  async function buildTree(path: string, depth = 0): Promise<ExplorerTreeNode> {
+    const node = await vfs.read(path);
+    const entry: ExplorerTreeNode = {
+      path: node.path,
+      name: node.name,
+      children: [],
+    };
+
+    if (depth > 2) {
+      return entry;
+    }
+
+    const entries = await vfs.list(path);
+    const directories = entries
+      .filter((item) => item.kind === 'directory')
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const directory of directories) {
+      entry.children.push(await buildTree(directory.path, depth + 1));
+    }
+
+    return entry;
+  }
+
+  function renderTreeNode(node: ExplorerTreeNode, host: HTMLElement) {
+    const item = document.createElement('div');
+    item.className = 'win95-explorer__tree-item';
+    item.dataset.path = node.path;
+    item.textContent = node.name;
+    if (normalize(node.path) === normalize(currentPath)) {
+      item.className += ' win95-explorer__tree-item--selected';
+    }
+    item.addEventListener('click', () => {
+      void setPath(node.path);
+    });
+    host.appendChild(item);
+
+    if (node.children.length > 0) {
+      const childContainer = document.createElement('div');
+      childContainer.className = 'win95-explorer__tree-children';
+      host.appendChild(childContainer);
+      node.children.forEach((child) => renderTreeNode(child, childContainer));
+    }
+  }
+
+  async function renderTree() {
+    if (!treePane) {
+      return;
+    }
+
+    const token = ++treeRenderToken;
+    const tree = await buildTree('C:/');
+    if (!treePane || token !== treeRenderToken) {
+      return;
+    }
+    treePane.innerHTML = '';
+    renderTreeNode(tree, treePane);
+  }
+
+  function renderBreadcrumbs(path: string) {
+    if (!breadcrumbs) {
+      return;
+    }
+
+    breadcrumbs.innerHTML = '';
+    const segments = path.split('/');
+    let accumulator = segments.shift() ?? '';
+    const drive = accumulator;
+    const driveButton = document.createElement('button');
+    driveButton.textContent = drive;
+    driveButton.addEventListener('click', () => {
+      void setPath(`${drive}/`);
+    });
+    breadcrumbs.appendChild(driveButton);
+
+    segments.forEach((segment) => {
+      if (!segment) {
+        return;
+      }
+      accumulator = `${accumulator}/${segment}`;
+      const crumb = document.createElement('button');
+      crumb.textContent = segment;
+      crumb.addEventListener('click', () => {
+        void setPath(accumulator);
+      });
+      breadcrumbs.appendChild(crumb);
+    });
+  }
+
+  function renderListItem(entry: VfsNode): HTMLElement {
+    const item = document.createElement('div');
+    item.className = 'win95-explorer__details-item';
+    item.dataset.path = entry.path;
+    item.dataset.kind = entry.kind;
+    item.textContent = entry.name;
+    if (entry.kind === 'directory') {
+      item.addEventListener('dblclick', () => {
+        void setPath(entry.path);
+      });
+    }
+    return item;
+  }
+
+  async function renderDetails() {
+    if (!detailsPane) {
+      return;
+    }
+
+    const entries = await vfs.list(currentPath);
+    detailsPane.innerHTML = '';
+    entries
+      .sort((a, b) => {
+        if (a.kind === b.kind) {
+          return a.name.localeCompare(b.name);
+        }
+        if (a.kind === 'directory') {
+          return -1;
+        }
+        if (b.kind === 'directory') {
+          return 1;
+        }
+        return a.name.localeCompare(b.name);
+      })
+      .forEach((entry) => {
+        detailsPane!.appendChild(renderListItem(entry));
+      });
+  }
+
+  function bindDetailWatcher() {
+    if (detailWatcher) {
+      detailWatcher();
+      detailWatcher = null;
+    }
+    detailWatcher = vfs.watch(currentPath, (_event: VfsWatchEvent) => {
+      void renderDetails();
+    });
+  }
+
+  async function setPath(path: string): Promise<void> {
+    currentPath = normalize(path);
+    if (container) {
+      container.dataset.path = currentPath;
+    }
+    bindDetailWatcher();
+    renderBreadcrumbs(currentPath);
+    await renderDetails();
+    await renderTree();
+  }
+
+  function mount(host: HTMLElement) {
+    clearHost();
+    container = document.createElement('div');
+    container.className = 'win95-explorer';
+    container.dataset.path = currentPath;
+
+    const layout = document.createElement('div');
+    layout.className = 'win95-explorer__layout';
+
+    treePane = document.createElement('div');
+    treePane.className = 'win95-explorer__tree';
+    layout.appendChild(treePane);
+
+    const content = document.createElement('div');
+    content.className = 'win95-explorer__content';
+
+    const breadcrumbBar = document.createElement('div');
+    breadcrumbBar.className = 'win95-explorer__breadcrumbs';
+    content.appendChild(breadcrumbBar);
+    breadcrumbs = breadcrumbBar;
+
+    detailsPane = document.createElement('div');
+    detailsPane.className = 'win95-explorer__details';
+    content.appendChild(detailsPane);
+
+    layout.appendChild(content);
+    container.appendChild(layout);
+    host.appendChild(container);
+
+    teardown.push(
+      vfs.watch('C:/', () => {
+        void renderTree();
+      }),
+    );
+
+    bindDetailWatcher();
+    renderBreadcrumbs(currentPath);
+    void renderTree();
+    void renderDetails();
+  }
+
+  function destroy() {
+    if (detailWatcher) {
+      detailWatcher();
+      detailWatcher = null;
+    }
+
+    teardown.splice(0).forEach((fn) => fn());
+    if (container) {
+      container.remove();
+    }
+    container = null;
+    treePane = null;
+    detailsPane = null;
+  }
+
+  return {
+    mount,
+    destroy,
+    setPath,
+    getCurrentPath() {
+      return currentPath;
+    },
+  };
+}

--- a/win95sim_v2/src/services/vfs/OWNERS
+++ b/win95sim_v2/src/services/vfs/OWNERS
@@ -1,0 +1,1 @@
+phase-02-team

--- a/win95sim_v2/src/services/vfs/index.ts
+++ b/win95sim_v2/src/services/vfs/index.ts
@@ -1,0 +1,544 @@
+import { createEventBus, EventBus } from '@core/kernel/eventBus';
+import { createRecycleBin } from './recycle-bin';
+import { basename, comparePathDepth, dirname, isDescendant, isRoot, normalizePath, toDisplayName } from './utils/path';
+import { lookupMime } from './utils/mime';
+import { lookupIcon } from './utils/icons';
+import type {
+  CreateVfsServiceOptions,
+  VfsDirectoryNode,
+  VfsFileNode,
+  VfsNode,
+  VfsRecycleBin,
+  VfsSearchOptions,
+  VfsService,
+  VfsShortcutNode,
+  VfsWatchEvent,
+  VfsWatchEventType,
+} from './types';
+
+interface InternalDirectoryNode extends VfsDirectoryNode {
+  kind: 'directory';
+  icon: string;
+}
+
+interface InternalFileNode extends VfsFileNode {
+  kind: 'file';
+  icon: string;
+  encoding: 'binary' | 'text';
+}
+
+interface InternalShortcutNode extends VfsShortcutNode {
+  kind: 'shortcut';
+  icon: string;
+}
+
+type InternalNode = InternalDirectoryNode | InternalFileNode | InternalShortcutNode;
+
+type Watcher = (event: VfsWatchEvent) => void;
+
+interface WatchBucket {
+  path: string;
+  handlers: Set<Watcher>;
+}
+
+const DEFAULT_DRIVES = ['C:/'];
+
+function now(): number {
+  return Date.now();
+}
+
+function toPublic(node: InternalNode, includeContent = false): VfsNode {
+  if (node.kind === 'directory') {
+    return {
+      ...node,
+      children: [...node.children],
+    };
+  }
+
+  if (node.kind === 'file') {
+    return {
+      ...node,
+      content: includeContent ? new Uint8Array(node.content) : new Uint8Array(0),
+      textContent: includeContent ? node.textContent : undefined,
+    };
+  }
+
+  return { ...node };
+}
+
+function ensureText(value: string | Uint8Array): { content: Uint8Array; text?: string; encoding: 'binary' | 'text' } {
+  if (typeof value === 'string') {
+    const encoder = new TextEncoder();
+    return { content: encoder.encode(value), text: value, encoding: 'text' };
+  }
+
+  return { content: new Uint8Array(value), encoding: 'binary' };
+}
+
+function createDirectoryNode(path: string, metadata?: Record<string, unknown>): InternalDirectoryNode {
+  const normalized = normalizePath(path);
+  return {
+    path: normalized,
+    name: toDisplayName(normalized),
+    kind: 'directory',
+    size: 0,
+    modified: now(),
+    children: [],
+    icon: lookupIcon('directory'),
+    metadata,
+  };
+}
+
+function createFileNode(path: string, payload: { content: Uint8Array; text?: string; encoding: 'binary' | 'text'; metadata?: Record<string, unknown> }): InternalFileNode {
+  const normalized = normalizePath(path);
+  const { mime, icon } = lookupMime(normalized);
+  return {
+    path: normalized,
+    name: basename(normalized),
+    kind: 'file',
+    size: payload.content.byteLength,
+    modified: now(),
+    mimeType: mime,
+    icon: lookupIcon(icon),
+    content: payload.content,
+    textContent: payload.encoding === 'text' ? payload.text : undefined,
+    encoding: payload.encoding,
+    metadata: payload.metadata,
+  };
+}
+
+function createShortcutNode(path: string, target: string, metadata?: Record<string, unknown>): InternalShortcutNode {
+  const normalized = normalizePath(path);
+  return {
+    path: normalized,
+    name: basename(normalized),
+    kind: 'shortcut',
+    size: 0,
+    modified: now(),
+    target: normalizePath(target),
+    icon: lookupIcon('shortcut'),
+    metadata,
+  };
+}
+
+interface SerializedNode {
+  node: InternalNode;
+  children: SerializedNode[];
+}
+
+function serializeTree(node: InternalNode, getChildren: (path: string) => InternalNode[]): SerializedNode {
+  return {
+    node: toInternalClone(node),
+    children: node.kind === 'directory' ? getChildren(node.path).map((child) => serializeTree(child, getChildren)) : [],
+  };
+}
+
+function toInternalClone(node: InternalNode): InternalNode {
+  if (node.kind === 'directory') {
+    return {
+      ...node,
+      children: [...node.children],
+    };
+  }
+
+  if (node.kind === 'file') {
+    return {
+      ...node,
+      content: new Uint8Array(node.content),
+      textContent: node.textContent,
+    };
+  }
+
+  return { ...node };
+}
+
+function flattenSerialized(node: SerializedNode): InternalNode[] {
+  const result: InternalNode[] = [toInternalClone(node.node)];
+  node.children.forEach((child) => {
+    result.push(...flattenSerialized(child));
+  });
+  return result;
+}
+
+export function createVfsService(options: CreateVfsServiceOptions = {}): VfsService {
+  const bus: EventBus = createEventBus();
+  const nodes = new Map<string, InternalNode>();
+  const watchers: WatchBucket[] = [];
+  const { bin: recycleBin, capture, restore } = createRecycleBin();
+
+  function emit(type: VfsWatchEventType, node: InternalNode, previousPath?: string) {
+    const event: VfsWatchEvent = { type, node: toPublic(node, true), previousPath };
+    watchers.forEach((bucket) => {
+      if (isDescendant(bucket.path, node.path)) {
+        bucket.handlers.forEach((handler) => handler(event));
+        return;
+      }
+
+      if (previousPath && isDescendant(bucket.path, previousPath)) {
+        bucket.handlers.forEach((handler) => handler(event));
+      }
+    });
+    bus.emit(`vfs:${type}`, event);
+  }
+
+  function ensureDirectoryExists(path: string) {
+    const normalized = normalizePath(path);
+    if (nodes.has(normalized)) {
+      const entry = nodes.get(normalized)!;
+      if (entry.kind !== 'directory') {
+        throw new Error(`Path ${normalized} is not a directory`);
+      }
+      return entry;
+    }
+
+    if (isRoot(normalized)) {
+      const created = createDirectoryNode(normalized);
+      nodes.set(normalized, created);
+      return created;
+    }
+
+    const parent = ensureDirectoryExists(dirname(normalized));
+    const directory = createDirectoryNode(normalized);
+    parent.children.push(directory.path);
+    nodes.set(normalized, directory);
+    emit('created', directory);
+    return directory;
+  }
+
+  function addNode(node: InternalNode) {
+    const normalized = normalizePath(node.path);
+    const parentPath = dirname(normalized);
+    const parent = ensureDirectoryExists(parentPath);
+    if (!parent.children.includes(normalized)) {
+      parent.children.push(normalized);
+      parent.modified = now();
+    }
+    nodes.set(normalized, node);
+  }
+
+  function removeNode(path: string) {
+    const normalized = normalizePath(path);
+    const node = nodes.get(normalized);
+    if (!node) {
+      throw new Error(`Unknown path ${normalized}`);
+    }
+
+    if (node.kind === 'directory') {
+      [...node.children].forEach((child) => removeNode(child));
+    }
+
+    nodes.delete(normalized);
+    if (!isRoot(normalized)) {
+      const parent = nodes.get(dirname(normalized));
+      if (parent && parent.kind === 'directory') {
+        parent.children = parent.children.filter((entry) => entry !== normalized);
+      }
+    }
+    return node;
+  }
+
+  function hydrateTree(tree: SerializedNode) {
+    const flat = flattenSerialized(tree).sort((a, b) => comparePathDepth(a.path, b.path));
+    flat.forEach((node) => {
+      if (node.kind === 'directory') {
+        node.children = [...node.children];
+      }
+      addNode(node);
+    });
+  }
+
+  function list(path: string): Promise<VfsNode[]> {
+    const normalized = normalizePath(path);
+    const node = nodes.get(normalized);
+    if (!node) {
+      throw new Error(`Unknown path ${normalized}`);
+    }
+
+    if (node.kind !== 'directory') {
+      throw new Error(`Path ${normalized} is not a directory`);
+    }
+
+    const entries = node.children
+      .map((child) => toPublic(nodes.get(child)!, false))
+      .sort((a, b) => a.name.localeCompare(b.name));
+    return Promise.resolve(entries);
+  }
+
+  async function read(path: string): Promise<VfsNode> {
+    const normalized = normalizePath(path);
+    const node = nodes.get(normalized);
+    if (!node) {
+      throw new Error(`Unknown path ${normalized}`);
+    }
+
+    return toPublic(node, true);
+  }
+
+  async function writeFile(path: string, contents: string | Uint8Array, metadata?: Record<string, unknown>): Promise<VfsNode> {
+    const normalized = normalizePath(path);
+    const parent = ensureDirectoryExists(dirname(normalized));
+    const payload = ensureText(contents);
+    let node = nodes.get(normalized);
+    const existed = Boolean(node);
+
+    if (node && node.kind !== 'file') {
+      throw new Error(`Cannot write file over ${node.kind}`);
+    }
+
+    node = createFileNode(normalized, { ...payload, metadata });
+    addNode(node);
+    parent.modified = now();
+    emit(existed ? 'updated' : 'created', node);
+    return toPublic(node, true);
+  }
+
+  async function makeDirectory(path: string, metadata?: Record<string, unknown>): Promise<VfsNode> {
+    const normalized = normalizePath(path);
+    if (nodes.has(normalized)) {
+      const existing = nodes.get(normalized)!;
+      if (existing.kind !== 'directory') {
+        throw new Error(`Cannot convert ${normalized} to directory`);
+      }
+      return toPublic(existing, false);
+    }
+
+    const parent = ensureDirectoryExists(dirname(normalized));
+    const directory = createDirectoryNode(normalized, metadata);
+    addNode(directory);
+    parent.modified = now();
+    emit('created', directory);
+    return toPublic(directory, false);
+  }
+
+  async function createShortcut(path: string, target: string, metadata?: Record<string, unknown>): Promise<VfsNode> {
+    const normalized = normalizePath(path);
+    const shortcut = createShortcutNode(normalized, target, metadata);
+    addNode(shortcut);
+    emit('created', shortcut);
+    return toPublic(shortcut, false);
+  }
+
+  async function move(source: string, destination: string): Promise<VfsNode> {
+    const from = normalizePath(source);
+    const to = normalizePath(destination);
+    const node = nodes.get(from);
+    if (!node) {
+      throw new Error(`Unknown path ${from}`);
+    }
+
+    if (nodes.has(to)) {
+      throw new Error(`Destination already exists: ${to}`);
+    }
+
+    const oldParent = nodes.get(dirname(from));
+    if (oldParent && oldParent.kind === 'directory') {
+      oldParent.children = oldParent.children.filter((entry) => entry !== from);
+      oldParent.modified = now();
+    }
+
+    const newParent = ensureDirectoryExists(dirname(to));
+    if (!newParent.children.includes(to)) {
+      newParent.children.push(to);
+    }
+    newParent.modified = now();
+
+    const pathMap = new Map<string, string>();
+    pathMap.set(from, to);
+
+    if (node.kind === 'directory') {
+      const prefixFrom = from.endsWith('/') ? from : `${from}/`;
+      const prefixTo = to.endsWith('/') ? to : `${to}/`;
+      const updates: Array<{ oldPath: string; newPath: string; node: InternalNode }> = [];
+
+      nodes.forEach((entry, key) => {
+        if (key === from) {
+          return;
+        }
+        if (!key.startsWith(prefixFrom)) {
+          return;
+        }
+        const suffix = key.slice(prefixFrom.length);
+        const nextPath = normalizePath(`${prefixTo}${suffix}`);
+        pathMap.set(key, nextPath);
+        updates.push({ oldPath: key, newPath: nextPath, node: entry });
+      });
+
+      nodes.delete(from);
+      node.path = to;
+      node.name = basename(to);
+      node.modified = now();
+      node.children = node.children.map((childPath) => pathMap.get(childPath) ?? childPath);
+      nodes.set(to, node);
+
+      updates.forEach(({ oldPath, newPath, node: entry }) => {
+        nodes.delete(oldPath);
+        entry.path = newPath;
+        entry.name = basename(newPath);
+        entry.modified = now();
+        if (entry.kind === 'directory') {
+          entry.children = entry.children.map((childPath) => pathMap.get(childPath) ?? childPath);
+        }
+        nodes.set(newPath, entry);
+      });
+    } else {
+      nodes.delete(from);
+      node.path = to;
+      node.name = basename(to);
+      node.modified = now();
+      nodes.set(to, node);
+    }
+
+    emit('moved', node, from);
+    return toPublic(node, true);
+  }
+
+  async function remove(path: string): Promise<void> {
+    const normalized = normalizePath(path);
+    const node = nodes.get(normalized);
+    if (!node) {
+      throw new Error(`Unknown path ${normalized}`);
+    }
+
+    const serialized = serializeTree(node, (candidate) => {
+      const entry = nodes.get(candidate);
+      if (!entry || entry.kind !== 'directory') {
+        return [];
+      }
+      return entry.children.map((child) => nodes.get(child)!).filter(Boolean);
+    });
+
+    const entry = capture({ tree: serialized, originalPath: normalized });
+    removeNode(normalized);
+    emit('deleted', node);
+    bus.emit('vfs:recycle-bin', entry);
+  }
+
+  function watchPath(path: string, handler: (event: VfsWatchEvent) => void): () => void {
+    const normalized = normalizePath(path);
+    let bucket = watchers.find((entry) => entry.path === normalized);
+    if (!bucket) {
+      bucket = { path: normalized, handlers: new Set() };
+      watchers.push(bucket);
+    }
+    bucket.handlers.add(handler);
+    return () => {
+      bucket!.handlers.delete(handler);
+      if (bucket!.handlers.size === 0) {
+        const index = watchers.indexOf(bucket!);
+        if (index >= 0) {
+          watchers.splice(index, 1);
+        }
+      }
+    };
+  }
+
+  async function search(query: string, options: VfsSearchOptions = {}): Promise<VfsNode[]> {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      return [];
+    }
+
+    const within = options.within ? normalizePath(options.within) : undefined;
+    const comparator = options.caseSensitive ? (value: string) => value : (value: string) => value.toLowerCase();
+    const target = comparator(trimmed);
+
+    const results: VfsNode[] = [];
+    nodes.forEach((node) => {
+      if (node.kind === 'directory') {
+        return;
+      }
+
+      if (within && !isDescendant(within, node.path)) {
+        return;
+      }
+
+      const name = comparator(node.name);
+      if (name.includes(target)) {
+        results.push(toPublic(node, false));
+        return;
+      }
+
+      if (options.includeContent && node.kind === 'file' && node.encoding === 'text' && node.textContent) {
+        const content = comparator(node.textContent);
+        if (content.includes(target)) {
+          results.push(toPublic(node, false));
+        }
+      }
+    });
+
+    return results.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  async function resolveShortcut(path: string): Promise<VfsNode> {
+    const normalized = normalizePath(path);
+    const node = nodes.get(normalized);
+    if (!node || node.kind !== 'shortcut') {
+      throw new Error(`Shortcut not found: ${normalized}`);
+    }
+
+    return read(node.target);
+  }
+
+  function restoreFromRecycleBin(id: string): VfsNode[] {
+    const tree = restore(id);
+    if (!tree) {
+      throw new Error(`Recycle Bin entry ${id} not found`);
+    }
+
+    const flattened = flattenSerialized(tree).map((entry) => entry.path);
+    hydrateTree(tree);
+    return flattened.map((path) => {
+      const entry = nodes.get(path)!;
+      emit('restored', entry);
+      return toPublic(entry, true);
+    });
+  }
+
+  function bootstrap() {
+    DEFAULT_DRIVES.forEach((drive) => {
+      const normalized = normalizePath(drive);
+      if (!nodes.has(normalized)) {
+        nodes.set(normalized, createDirectoryNode(normalized));
+      }
+    });
+
+    options.seed?.forEach((seed) => {
+      if (seed.kind === 'directory') {
+        void makeDirectory(seed.path, undefined);
+      } else if (seed.kind === 'file') {
+        void writeFile(seed.path, seed.content ?? '', undefined);
+      } else if (seed.kind === 'shortcut' && seed.target) {
+        void createShortcut(seed.path, seed.target, undefined);
+      }
+    });
+  }
+
+  bootstrap();
+
+  const recycleBinFacade: VfsRecycleBin = {
+    list: () => recycleBin.list(),
+    empty: () => recycleBin.empty(),
+    restore: (id: string) => restoreFromRecycleBin(id),
+  };
+
+  const service: VfsService = {
+    list,
+    read,
+    writeFile,
+    makeDirectory,
+    createShortcut,
+    move,
+    remove,
+    watch(path, handler) {
+      return watchPath(path, handler);
+    },
+    search,
+    resolveShortcut,
+    recycleBin: recycleBinFacade,
+    bus,
+  };
+
+  return service;
+}
+
+export type { VfsService, VfsNode, VfsRecycleBin, VfsWatchEvent } from './types';

--- a/win95sim_v2/src/services/vfs/recycle-bin.ts
+++ b/win95sim_v2/src/services/vfs/recycle-bin.ts
@@ -1,0 +1,124 @@
+import { normalizePath } from './utils/path';
+import type { VfsNode, VfsRecycleBin, VfsRecycleBinEntry } from './types';
+
+interface SerializedNode {
+  node: VfsNode;
+  children: SerializedNode[];
+}
+
+interface StoredEntry {
+  id: string;
+  originalPath: string;
+  deletedAt: number;
+  tree: SerializedNode;
+}
+
+let counter = 0;
+
+function cloneNode(node: VfsNode): VfsNode {
+  if (node.kind === 'file') {
+    return {
+      ...node,
+      content: new Uint8Array(node.content),
+      textContent: node.textContent,
+      children: undefined as never,
+    };
+  }
+
+  if (node.kind === 'directory') {
+    return {
+      ...node,
+      children: [...node.children],
+    };
+  }
+
+  return { ...node };
+}
+
+function cloneTree(tree: SerializedNode): SerializedNode {
+  return {
+    node: cloneNode(tree.node),
+    children: tree.children.map((child) => cloneTree(child)),
+  };
+}
+
+export interface RecycleBinCapture {
+  tree: SerializedNode;
+  originalPath: string;
+}
+
+export function createRecycleBin(): {
+  bin: VfsRecycleBin;
+  capture(entry: RecycleBinCapture): VfsRecycleBinEntry;
+  restore(id: string): SerializedNode | undefined;
+} {
+  const entries: StoredEntry[] = [];
+
+  function list(): VfsRecycleBinEntry[] {
+    return entries.map((entry) => ({
+      id: entry.id,
+      originalPath: entry.originalPath,
+      name: entry.tree.node.name,
+      kind: entry.tree.node.kind,
+      size: entry.tree.node.size,
+      deletedAt: entry.deletedAt,
+    }));
+  }
+
+  function empty(): void {
+    entries.splice(0, entries.length);
+  }
+
+  function restore(id: string): SerializedNode | undefined {
+    const index = entries.findIndex((entry) => entry.id === id);
+    if (index === -1) {
+      return undefined;
+    }
+
+    const [entry] = entries.splice(index, 1);
+    return cloneTree(entry.tree);
+  }
+
+  function capture(entry: RecycleBinCapture): VfsRecycleBinEntry {
+    const id = `rb-${Date.now()}-${counter++}`;
+    const stored: StoredEntry = {
+      id,
+      originalPath: normalizePath(entry.originalPath),
+      deletedAt: Date.now(),
+      tree: cloneTree(entry.tree),
+    };
+    entries.push(stored);
+    return {
+      id,
+      originalPath: stored.originalPath,
+      name: stored.tree.node.name,
+      kind: stored.tree.node.kind,
+      size: stored.tree.node.size,
+      deletedAt: stored.deletedAt,
+    };
+  }
+
+  return {
+    bin: {
+      list,
+      empty,
+      restore(id) {
+        const restored = restore(id);
+        if (!restored) {
+          throw new Error(`Recycle Bin entry ${id} not found`);
+        }
+        const collected: VfsNode[] = [];
+
+        function flatten(node: SerializedNode) {
+          collected.push(cloneNode(node.node));
+          node.children.forEach(flatten);
+        }
+
+        flatten(restored);
+        return collected;
+      },
+    },
+    capture,
+    restore,
+  };
+}

--- a/win95sim_v2/src/services/vfs/types.ts
+++ b/win95sim_v2/src/services/vfs/types.ts
@@ -1,0 +1,102 @@
+import type { EventBus } from '@core/kernel/eventBus';
+
+export type VfsNodeKind = 'file' | 'directory' | 'shortcut';
+
+export interface VfsNodeBase {
+  /** Normalized absolute path (e.g. `C:/Users`). */
+  path: string;
+  /** Friendly display name derived from the path. */
+  name: string;
+  kind: VfsNodeKind;
+  /**
+   * Size in bytes. For directories the size represents the cumulative size of
+   * the immediate children so the UI can surface rough totals.
+   */
+  size: number;
+  /** Unix epoch timestamp (ms) updated whenever the node mutates. */
+  modified: number;
+  /** Icon identifier used by Explorer; backed by `@services/vfs/utils/icons`. */
+  icon?: string;
+  /** Optional metadata bag for future extensions (icons, attributes, etc.). */
+  metadata?: Record<string, unknown>;
+}
+
+export interface VfsDirectoryNode extends VfsNodeBase {
+  kind: 'directory';
+  /** Normalized absolute paths to the directory's children. */
+  children: string[];
+}
+
+export interface VfsFileNode extends VfsNodeBase {
+  kind: 'file';
+  /** MIME type derived from the file extension. */
+  mimeType: string;
+  /** Encoded file contents. */
+  content: Uint8Array;
+  /** Optional decoded UTF-8 string for text-based files. */
+  textContent?: string;
+}
+
+export interface VfsShortcutNode extends VfsNodeBase {
+  kind: 'shortcut';
+  /** Target path the shortcut resolves to. */
+  target: string;
+}
+
+export type VfsNode = VfsDirectoryNode | VfsFileNode | VfsShortcutNode;
+
+export type VfsWatchEventType = 'created' | 'updated' | 'deleted' | 'moved' | 'restored';
+
+export interface VfsWatchEvent {
+  type: VfsWatchEventType;
+  node: VfsNode;
+  /** Previous normalized path when type is `moved` or `restored`. */
+  previousPath?: string;
+}
+
+export interface VfsSearchOptions {
+  /**
+   * When enabled the search routine will scan text content in addition to file
+   * and folder names.
+   */
+  includeContent?: boolean;
+  /** Case sensitivity flag. Defaults to `false` to match Windows Explorer. */
+  caseSensitive?: boolean;
+  /** Optional path constraint restricting the search scope. */
+  within?: string;
+}
+
+export interface VfsRecycleBinEntry {
+  id: string;
+  name: string;
+  originalPath: string;
+  kind: VfsNodeKind;
+  size: number;
+  deletedAt: number;
+}
+
+export interface VfsRecycleBin {
+  list(): VfsRecycleBinEntry[];
+  restore(id: string): VfsNode[];
+  empty(): void;
+}
+
+export interface CreateVfsServiceOptions {
+  /** Optional seed tree used by tests/fixtures. */
+  seed?: Array<{ path: string; kind: VfsNodeKind; content?: string | Uint8Array; target?: string }>;
+}
+
+export interface VfsService {
+  list(path: string): Promise<VfsNode[]>;
+  read(path: string): Promise<VfsNode>;
+  writeFile(path: string, contents: string | Uint8Array, metadata?: Record<string, unknown>): Promise<VfsNode>;
+  makeDirectory(path: string, metadata?: Record<string, unknown>): Promise<VfsNode>;
+  createShortcut(path: string, target: string, metadata?: Record<string, unknown>): Promise<VfsNode>;
+  move(source: string, destination: string): Promise<VfsNode>;
+  remove(path: string): Promise<void>;
+  watch(path: string, handler: (event: VfsWatchEvent) => void): () => void;
+  search(query: string, options?: VfsSearchOptions): Promise<VfsNode[]>;
+  resolveShortcut(path: string): Promise<VfsNode>;
+  recycleBin: VfsRecycleBin;
+  bus: EventBus;
+}

--- a/win95sim_v2/src/services/vfs/utils/icons.ts
+++ b/win95sim_v2/src/services/vfs/utils/icons.ts
@@ -1,0 +1,16 @@
+const ICON_TABLE = new Map<string, string>([
+  ['directory', 'folder'],
+  ['file', 'file'],
+  ['shortcut', 'shortcut'],
+  ['text', 'text'],
+  ['image', 'image'],
+  ['audio', 'audio'],
+]);
+
+export function lookupIcon(key: string): string {
+  return ICON_TABLE.get(key) ?? 'file';
+}
+
+export function registerIcon(key: string, identifier: string): void {
+  ICON_TABLE.set(key, identifier);
+}

--- a/win95sim_v2/src/services/vfs/utils/mime.ts
+++ b/win95sim_v2/src/services/vfs/utils/mime.ts
@@ -1,0 +1,28 @@
+const MIME_TABLE = new Map<string, { mime: string; icon: string }>([
+  ['txt', { mime: 'text/plain', icon: 'text' }],
+  ['md', { mime: 'text/markdown', icon: 'text' }],
+  ['json', { mime: 'application/json', icon: 'text' }],
+  ['png', { mime: 'image/png', icon: 'image' }],
+  ['jpg', { mime: 'image/jpeg', icon: 'image' }],
+  ['jpeg', { mime: 'image/jpeg', icon: 'image' }],
+  ['gif', { mime: 'image/gif', icon: 'image' }],
+  ['bmp', { mime: 'image/bmp', icon: 'image' }],
+  ['wav', { mime: 'audio/wav', icon: 'audio' }],
+  ['mp3', { mime: 'audio/mpeg', icon: 'audio' }],
+  ['lnk', { mime: 'application/x-ms-shortcut', icon: 'shortcut' }],
+]);
+
+const DEFAULT_ENTRY = { mime: 'application/octet-stream', icon: 'file' };
+
+export function lookupMime(path: string): { mime: string; icon: string } {
+  const match = /\.([^.]+)$/.exec(path.toLowerCase());
+  if (!match) {
+    return DEFAULT_ENTRY;
+  }
+
+  return MIME_TABLE.get(match[1]) ?? DEFAULT_ENTRY;
+}
+
+export function registerMime(extension: string, mime: string, icon: string): void {
+  MIME_TABLE.set(extension.replace(/^\./, '').toLowerCase(), { mime, icon });
+}

--- a/win95sim_v2/src/services/vfs/utils/path.ts
+++ b/win95sim_v2/src/services/vfs/utils/path.ts
@@ -1,0 +1,125 @@
+export interface PathParts {
+  drive: string;
+  segments: string[];
+}
+
+const DRIVE_PATTERN = /^[a-zA-Z]:/;
+
+export function normalizePath(input: string): string {
+  if (!input) {
+    throw new Error('Path must be a non-empty string');
+  }
+
+  let path = input.replace(/\\/g, '/');
+  if (!DRIVE_PATTERN.test(path)) {
+    throw new Error(`Path must include a drive letter: ${input}`);
+  }
+
+  const drive = path.slice(0, 2).toUpperCase();
+  let rest = path.slice(2);
+  if (rest === '') {
+    rest = '/';
+  }
+
+  if (!rest.startsWith('/')) {
+    rest = `/${rest}`;
+  }
+
+  // Collapse repeated slashes and trim trailing slashes (except for root).
+  const segments = rest
+    .split('/')
+    .filter((segment) => segment.length > 0);
+
+  const normalized = `${drive}/${segments.join('/')}`;
+  return normalized.endsWith('/') && normalized.length > 3 ? normalized.slice(0, -1) : normalized;
+}
+
+export function parts(path: string): PathParts {
+  const normalized = normalizePath(path);
+  const drive = normalized.slice(0, 2);
+  const rest = normalized.length > 3 ? normalized.slice(3) : '';
+  const segments = rest === '' ? [] : rest.split('/');
+  return { drive, segments };
+}
+
+export function basename(path: string): string {
+  const { segments, drive } = parts(path);
+  if (segments.length === 0) {
+    return `${drive}/`;
+  }
+
+  return segments[segments.length - 1];
+}
+
+export function dirname(path: string): string {
+  const { segments, drive } = parts(path);
+  if (segments.length <= 1) {
+    return `${drive}/`;
+  }
+
+  return `${drive}/${segments.slice(0, -1).join('/')}`;
+}
+
+export function join(base: string, segment: string): string {
+  if (!segment) {
+    return normalizePath(base);
+  }
+
+  const normalizedBase = normalizePath(base);
+  if (segment.includes(':')) {
+    return normalizePath(segment);
+  }
+
+  const suffix = segment.replace(/^\\+|\/+/, '').replace(/\\/g, '/');
+  const combined = normalizedBase.endsWith('/') ? `${normalizedBase}${suffix}` : `${normalizedBase}/${suffix}`;
+  return normalizePath(combined);
+}
+
+export function isRoot(path: string): boolean {
+  const normalized = normalizePath(path);
+  return normalized.length === 3 && normalized.endsWith('/');
+}
+
+export function isDescendant(parent: string, candidate: string): boolean {
+  const normalizedParent = normalizePath(parent);
+  const normalizedCandidate = normalizePath(candidate);
+  if (normalizedParent === normalizedCandidate) {
+    return true;
+  }
+
+  if (!normalizedCandidate.startsWith(normalizedParent)) {
+    return false;
+  }
+
+  if (isRoot(normalizedParent)) {
+    return true;
+  }
+
+  const char = normalizedCandidate.charAt(normalizedParent.length);
+  return char === '/' || char === '';
+}
+
+export function comparePathDepth(a: string, b: string): number {
+  const depthA = parts(a).segments.length;
+  const depthB = parts(b).segments.length;
+  return depthA - depthB;
+}
+
+export function toDisplayName(path: string): string {
+  const normalized = normalizePath(path);
+  const { segments, drive } = parts(normalized);
+  if (segments.length === 0) {
+    return `${drive}`;
+  }
+  return segments[segments.length - 1];
+}
+
+export function parentChain(path: string): string[] {
+  const { drive, segments } = parts(path);
+  const chain: string[] = [`${drive}/`];
+  segments.forEach((_segment, index) => {
+    const entry = segments.slice(0, index + 1).join('/');
+    chain.push(`${drive}/${entry}`);
+  });
+  return chain;
+}

--- a/win95sim_v2/tests/fixtures/vfs/sampleTree.js
+++ b/win95sim_v2/tests/fixtures/vfs/sampleTree.js
@@ -1,0 +1,10 @@
+module.exports = function sampleTree() {
+  return [
+    { path: 'C:/Projects', kind: 'directory' },
+    { path: 'C:/Projects/Phase02.txt', kind: 'file', content: 'Explorer requirements' },
+    { path: 'C:/Projects/Plans/timeline.md', kind: 'file', content: 'Milestones' },
+    { path: 'C:/Projects/Plans', kind: 'directory' },
+    { path: 'C:/Desktop', kind: 'directory' },
+    { path: 'C:/Desktop/Explorer.lnk', kind: 'shortcut', target: 'C:/Projects' },
+  ];
+};

--- a/win95sim_v2/tests/helpers/fakeDom.js
+++ b/win95sim_v2/tests/helpers/fakeDom.js
@@ -106,14 +106,25 @@ function withFakeDom(callback) {
   const previousDocument = global.document;
   const document = new FakeDocument();
   global.document = document;
-  try {
-    return callback({ document, FakeElement });
-  } finally {
+
+  const restore = () => {
     if (previousDocument === undefined) {
       delete global.document;
     } else {
       global.document = previousDocument;
     }
+  };
+
+  try {
+    const result = callback({ document, FakeElement });
+    if (result && typeof result.then === 'function') {
+      return Promise.resolve(result).finally(restore);
+    }
+    restore();
+    return result;
+  } catch (error) {
+    restore();
+    throw error;
   }
 }
 

--- a/win95sim_v2/tests/phase02-filesystem.test.js
+++ b/win95sim_v2/tests/phase02-filesystem.test.js
@@ -1,11 +1,127 @@
 const test = require('node:test');
+const assert = require('node:assert/strict');
 
-// Placeholder suite for the Virtual File System Explorer deliverables.
+const { loadModule } = require('./helpers/loadModule');
+const { withFakeDom } = require('./helpers/fakeDom');
+const sampleTree = require('./fixtures/vfs/sampleTree');
 
-test('filesystem service returns directory listings', (t) => {
-  t.todo('mock in-memory filesystem in Phase 02 implementation');
+function flush() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+test('filesystem service supports CRUD, watchers, search, and recycle bin', async () => {
+  const { createVfsService } = loadModule('src/services/vfs/index.ts');
+  const vfs = createVfsService({ seed: sampleTree() });
+
+  const events = [];
+  const stopWatching = vfs.watch('C:/Projects', (event) => {
+    events.push({ type: event.type, path: event.node.path, previousPath: event.previousPath });
+  });
+
+  const readme = await vfs.writeFile('C:/Projects/README.txt', 'Phase 02 ready');
+  assert.equal(readme.textContent, 'Phase 02 ready');
+  assert.equal(readme.mimeType, 'text/plain');
+
+  await vfs.writeFile('C:/Projects/README.txt', 'Phase 02 updated');
+  await vfs.makeDirectory('C:/Projects/Archive');
+  await vfs.writeFile('C:/Projects/Archive/log.txt', 'log entry');
+
+  const moved = await vfs.move('C:/Projects/Archive', 'C:/Archive/Archive');
+  assert.equal(moved.path, 'C:/Archive/Archive');
+  const movedFile = await vfs.read('C:/Archive/Archive/log.txt');
+  assert.equal(movedFile.textContent, 'log entry');
+
+  await vfs.createShortcut('C:/Desktop/Projects.lnk', 'C:/Projects/README.txt');
+  const resolvedShortcut = await vfs.resolveShortcut('C:/Desktop/Projects.lnk');
+  assert.equal(resolvedShortcut.path, 'C:/Projects/README.txt');
+
+  const nameResults = await vfs.search('readme');
+  assert.equal(nameResults.length, 1);
+  const contentResults = await vfs.search('updated', { includeContent: true });
+  assert.equal(contentResults.length, 1);
+
+  await vfs.remove('C:/Projects/README.txt');
+  const entries = vfs.recycleBin.list();
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].originalPath, 'C:/Projects/README.txt');
+  const restored = vfs.recycleBin.restore(entries[0].id);
+  assert.equal(restored.length, 1);
+  assert.equal(restored[0].path, 'C:/Projects/README.txt');
+  const restoredFile = await vfs.read('C:/Projects/README.txt');
+  assert.equal(restoredFile.textContent, 'Phase 02 updated');
+
+  stopWatching();
+
+  assert.deepEqual(
+    events.map((event) => event.type),
+    ['created', 'updated', 'created', 'created', 'moved', 'deleted', 'restored'],
+  );
+  assert.ok(events.some((event) => event.type === 'moved' && event.previousPath === 'C:/Projects/Archive'));
 });
 
-test('explorer app renders tree and details panes', (t) => {
-  t.todo('mount explorer UI once features are available');
+function extractTreeLabels(node) {
+  const labels = [];
+  node.children.forEach((child) => {
+    if (typeof child.className === 'string' && child.className.includes('win95-explorer__tree-item')) {
+      labels.push(child.textContent);
+    }
+    labels.push(...extractTreeLabels(child));
+  });
+  return labels;
+}
+
+function collectText(children) {
+  return children.map((node) => node.textContent);
+}
+
+test('explorer app renders tree and details panes reacting to VFS updates', async () => {
+  const { createVfsService } = loadModule('src/services/vfs/index.ts');
+  const { createExplorerApp } = loadModule('src/apps/explorer/index.ts');
+
+  const vfs = createVfsService({ seed: sampleTree() });
+
+  await withFakeDom(async () => {
+    const host = document.createElement('div');
+    const explorer = createExplorerApp({ vfs, startPath: 'C:/Projects' });
+    explorer.mount(host);
+
+    await flush();
+    await flush();
+
+    assert.equal(host.children.length, 1);
+    const container = host.children[0];
+    assert.equal(container.className, 'win95-explorer');
+    assert.equal(container.dataset.path, 'C:/Projects');
+
+    const layout = container.children[0];
+    const treePane = layout.children[0];
+    const content = layout.children[1];
+    const detailsPane = content.children[1];
+
+    // Root drive plus child directories should be present.
+    assert.equal(treePane.children[0].textContent, 'C:');
+    const treeLabels = extractTreeLabels(treePane);
+    assert.ok(treeLabels.includes('Projects'));
+
+    const detailNames = collectText(detailsPane.children);
+    assert.ok(detailNames.includes('Phase02.txt'));
+
+    await vfs.writeFile('C:/Projects/Notes.txt', 'Meeting notes');
+    await flush();
+    await flush();
+    const updatedNames = collectText(detailsPane.children);
+    assert.ok(updatedNames.includes('Notes.txt'));
+
+    await vfs.makeDirectory('C:/Projects/Assets');
+    await flush();
+    await flush();
+    const directoriesAfter = (await vfs.list('C:/Projects'))
+      .filter((entry) => entry.kind === 'directory')
+      .map((entry) => entry.name);
+    assert.ok(directoriesAfter.includes('Assets'));
+    const updatedTreeLabels = extractTreeLabels(treePane);
+    assert.ok(updatedTreeLabels.includes('Assets'));
+
+    explorer.destroy();
+  });
 });


### PR DESCRIPTION
## Summary
- implement an in-memory virtual file system service with watchers, recycle bin support, and utility helpers
- add the Explorer app module with tree/details panes that react to filesystem events plus accompanying docs and fixtures
- expand phase 02 tests and update the fake DOM helper so Explorer rendering can be exercised asynchronously

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f65c6667e48329928a2f9104574fd6