### PR TITLE
Implement phase 03 shell surface modules

### DIFF
--- a/win95sim_v2/docs/module-apis-v2.md
+++ b/win95sim_v2/docs/module-apis-v2.md
@@ -137,6 +137,51 @@ interface LocalizationService {
 }
 ```
 
+### `services/layout`
+Persists icon and surface geometry for desktop-aligned experiences.
+```ts
+interface LayoutPosition {
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+}
+
+interface LayoutSnapshot {
+  surfaceId: string;
+  items: Record<string, LayoutPosition>;
+  gridSize?: number;
+}
+
+interface LayoutService {
+  getSnapshot(surfaceId: string): LayoutSnapshot;
+  setItem(surfaceId: string, itemId: string, position: LayoutPosition, options?: { snapToGrid?: boolean }): LayoutSnapshot;
+  removeItem(surfaceId: string, itemId: string): LayoutSnapshot;
+  clear(surfaceId: string): LayoutSnapshot;
+  setGridSize(surfaceId: string, size: number): void;
+  bus: EventBus;
+}
+```
+
+### `services/recent-documents`
+Tracks recently opened documents for surfacing in the Start menu and Explorer.
+```ts
+interface RecentDocumentEntry {
+  id: string;
+  title: string;
+  path: string;
+  openedAt: number;
+  metadata?: Record<string, unknown>;
+}
+
+interface RecentDocumentsService {
+  add(entry: Omit<RecentDocumentEntry, 'openedAt'> & { openedAt?: number }): RecentDocumentEntry;
+  list(): RecentDocumentEntry[];
+  clear(): void;
+  bus: EventBus;
+}
+```
+
 ## UI primitives
 ### CSS tokens (`ui/tokens.css`)
 ```css

--- a/win95sim_v2/docs/shell-commands.md
+++ b/win95sim_v2/docs/shell-commands.md
@@ -1,0 +1,17 @@
+# Shell Command Reference
+
+Phase 03 introduces a small set of shell command identifiers that are consumed by the desktop, taskbar, and Start menu. These IDs are stable contracts for downstream phases and external plugins.
+
+| Command ID | Description |
+| --- | --- |
+| `shell:start:notepad` | Launch the Notepad application. |
+| `shell:start:paint` | Launch the Paint application. |
+| `shell:start:minesweeper` | Launch the Minesweeper game. |
+| `shell:start:control-panel` | Open the Control Panel surface. |
+| `shell:start:taskbar-settings` | Open the Taskbar & Start Menu settings panel. |
+| `shell:start:find-files` | Trigger the Find Files dialog. |
+| `shell:start:help` | Open the Windows Help viewer. |
+| `shell:start:run` | Focus the Run command dialog. |
+| `shell:start:shutdown` | Begin the system shutdown workflow. |
+
+Context menu commands use the shared menu registry exported from `src/ui/menus/`. Command identifiers should be prefixed with the owning feature (for example `desktop:refresh`) to avoid collisions. Future phases extending the shell should update this document when new commands are introduced.

--- a/win95sim_v2/src/apps/shell/desktop/index.ts
+++ b/win95sim_v2/src/apps/shell/desktop/index.ts
@@ -1,0 +1,129 @@
+import { LayoutPosition, LayoutService } from '@services/layout';
+
+export interface DesktopEntry {
+  id: string;
+  title: string;
+  resource: string;
+  type: 'file' | 'folder' | 'shortcut';
+  icon?: string;
+}
+
+export interface DesktopIcon extends DesktopEntry {
+  position: LayoutPosition;
+  selected: boolean;
+}
+
+export interface DesktopModuleOptions {
+  layout: LayoutService;
+  resolveEntries: () => DesktopEntry[];
+  onRename?: (entry: DesktopEntry, nextTitle: string) => void;
+  surfaceId?: string;
+  columnHeight?: number;
+  gridSize?: number;
+}
+
+export interface DesktopModule {
+  list(): DesktopIcon[];
+  move(id: string, position: LayoutPosition): void;
+  rename(id: string, nextTitle: string): DesktopEntry | undefined;
+  getSelection(): string[];
+  setSelection(ids: string[]): void;
+  clearSelection(): void;
+  arrange(): void;
+}
+
+const DEFAULT_SURFACE = '::desktop';
+const DEFAULT_COLUMN_HEIGHT = 6;
+
+export function createDesktopModule(options: DesktopModuleOptions): DesktopModule {
+  const layout = options.layout;
+  const surfaceId = options.surfaceId ?? DEFAULT_SURFACE;
+  const columnHeight = options.columnHeight ?? DEFAULT_COLUMN_HEIGHT;
+  const baseSnapshot = layout.getSnapshot(surfaceId);
+  const gridSize = options.gridSize ?? baseSnapshot.gridSize ?? 48;
+  const selection = new Set<string>();
+
+  layout.setGridSize(surfaceId, gridSize);
+
+  function ensureLayout(entries: DesktopEntry[]) {
+    const snapshot = layout.getSnapshot(surfaceId);
+    let column = 0;
+    let row = 0;
+    entries.forEach((entry) => {
+      if (!snapshot.items[entry.id]) {
+        const position = {
+          x: column * gridSize,
+          y: row * gridSize,
+        };
+        layout.setItem(surfaceId, entry.id, position);
+        row += 1;
+        if (row >= columnHeight) {
+          row = 0;
+          column += 1;
+        }
+      }
+    });
+  }
+
+  function list(): DesktopIcon[] {
+    const entries = options.resolveEntries();
+    ensureLayout(entries);
+    const snapshot = layout.getSnapshot(surfaceId);
+
+    return entries.map((entry) => ({
+      ...entry,
+      position: snapshot.items[entry.id],
+      selected: selection.has(entry.id),
+    }));
+  }
+
+  return {
+    list,
+    move(id, position) {
+      layout.setItem(surfaceId, id, position);
+    },
+    rename(id, nextTitle) {
+      const entries = options.resolveEntries();
+      const entry = entries.find((item) => item.id === id);
+      if (!entry) {
+        return undefined;
+      }
+
+      options.onRename?.(entry, nextTitle);
+      entry.title = nextTitle;
+      return entry;
+    },
+    getSelection() {
+      return Array.from(selection);
+    },
+    setSelection(ids) {
+      selection.clear();
+      ids.forEach((id) => selection.add(id));
+    },
+    clearSelection() {
+      selection.clear();
+    },
+    arrange() {
+      const entries = options.resolveEntries();
+      const next = entries
+        .slice()
+        .sort((a, b) => a.title.localeCompare(b.title));
+
+      layout.clear(surfaceId);
+
+      let column = 0;
+      let row = 0;
+      next.forEach((entry) => {
+        layout.setItem(surfaceId, entry.id, {
+          x: column * gridSize,
+          y: row * gridSize,
+        });
+        row += 1;
+        if (row >= columnHeight) {
+          row = 0;
+          column += 1;
+        }
+      });
+    },
+  };
+}

--- a/win95sim_v2/src/apps/shell/start-menu/data/manifest.json
+++ b/win95sim_v2/src/apps/shell/start-menu/data/manifest.json
@@ -1,0 +1,113 @@
+{
+  "sections": [
+    {
+      "id": "programs",
+      "label": "Programs",
+      "items": [
+        {
+          "id": "programs/accessories",
+          "label": "Accessories",
+          "type": "folder",
+          "items": [
+            {
+              "id": "programs/accessories/notepad",
+              "label": "Notepad",
+              "type": "command",
+              "command": "shell:start:notepad"
+            },
+            {
+              "id": "programs/accessories/paint",
+              "label": "Paint",
+              "type": "command",
+              "command": "shell:start:paint"
+            }
+          ]
+        },
+        {
+          "id": "programs/games",
+          "label": "Games",
+          "type": "folder",
+          "items": [
+            {
+              "id": "programs/games/minesweeper",
+              "label": "Minesweeper",
+              "type": "command",
+              "command": "shell:start:minesweeper"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "documents",
+      "label": "Documents",
+      "items": []
+    },
+    {
+      "id": "settings",
+      "label": "Settings",
+      "items": [
+        {
+          "id": "settings/control-panel",
+          "label": "Control Panel",
+          "type": "command",
+          "command": "shell:start:control-panel"
+        },
+        {
+          "id": "settings/taskbar",
+          "label": "Taskbar & Start Menu...",
+          "type": "command",
+          "command": "shell:start:taskbar-settings"
+        }
+      ]
+    },
+    {
+      "id": "find",
+      "label": "Find",
+      "items": [
+        {
+          "id": "find/files",
+          "label": "Files or Folders...",
+          "type": "command",
+          "command": "shell:start:find-files"
+        }
+      ]
+    },
+    {
+      "id": "help",
+      "label": "Help",
+      "items": [
+        {
+          "id": "help/windows-help",
+          "label": "Windows Help",
+          "type": "command",
+          "command": "shell:start:help"
+        }
+      ]
+    },
+    {
+      "id": "run",
+      "label": "Run...",
+      "items": [
+        {
+          "id": "run/command",
+          "label": "Run",
+          "type": "command",
+          "command": "shell:start:run"
+        }
+      ]
+    },
+    {
+      "id": "shutdown",
+      "label": "Shut Down...",
+      "items": [
+        {
+          "id": "shutdown/system",
+          "label": "Shut Down",
+          "type": "command",
+          "command": "shell:start:shutdown"
+        }
+      ]
+    }
+  ]
+}

--- a/win95sim_v2/src/apps/shell/start-menu/index.ts
+++ b/win95sim_v2/src/apps/shell/start-menu/index.ts
@@ -1,0 +1,143 @@
+import manifestData from './data/manifest.json';
+import { MenuSchema, MenuSchemaItem } from '@ui/menus';
+import { RecentDocumentEntry, RecentDocumentsService } from '@services/recent-documents';
+
+export type StartMenuItemType = 'folder' | 'command';
+
+export interface StartMenuManifestItem {
+  id: string;
+  label: string;
+  type?: StartMenuItemType;
+  command?: string;
+  items?: StartMenuManifestItem[];
+}
+
+export interface StartMenuManifestSection {
+  id: string;
+  label: string;
+  items: StartMenuManifestItem[];
+}
+
+export interface StartMenuManifest {
+  sections: StartMenuManifestSection[];
+}
+
+export interface StartMenuOptions {
+  manifest?: StartMenuManifest;
+  recentDocuments: RecentDocumentsService;
+}
+
+export interface StartMenuSection extends StartMenuManifestSection {}
+
+export interface StartMenuSearchResult {
+  id: string;
+  label: string;
+  path: string[];
+  command?: string;
+}
+
+export interface StartMenuModel {
+  open(): void;
+  close(): void;
+  toggle(): void;
+  isOpen(): boolean;
+  getSections(): StartMenuSection[];
+  getRecentDocuments(): RecentDocumentEntry[];
+  getMenuSchema(sectionId: string): MenuSchema;
+  search(query: string): StartMenuSearchResult[];
+}
+
+function cloneManifest(manifest: StartMenuManifest): StartMenuManifest {
+  return {
+    sections: manifest.sections.map((section) => ({
+      ...section,
+      items: section.items.map(cloneItem),
+    })),
+  };
+}
+
+function cloneItem(item: StartMenuManifestItem): StartMenuManifestItem {
+  return {
+    ...item,
+    items: item.items?.map(cloneItem),
+  };
+}
+
+function toMenuSchema(section: StartMenuManifestSection): MenuSchema {
+  return {
+    id: `start-menu:${section.id}`,
+    items: section.items.map(toMenuItem),
+  };
+}
+
+function toMenuItem(item: StartMenuManifestItem): MenuSchemaItem {
+  return {
+    id: item.id,
+    type: item.items?.length ? 'submenu' : 'command',
+    label: item.label,
+    command: item.command,
+    children: item.items?.map(toMenuItem),
+  };
+}
+
+function walkItems(section: StartMenuManifestSection, path: string[], results: StartMenuSearchResult[]) {
+  for (const item of section.items) {
+    const nextPath = [...path, item.label];
+    const type = item.type ?? (item.items?.length ? 'folder' : 'command');
+    if (type === 'command') {
+      results.push({
+        id: item.id,
+        label: item.label,
+        path: nextPath,
+        command: item.command,
+      });
+    }
+    if (item.items) {
+      walkItems({ id: section.id, label: section.label, items: item.items }, nextPath, results);
+    }
+  }
+}
+
+export function createStartMenuModel(options: StartMenuOptions): StartMenuModel {
+  const manifest = cloneManifest(options.manifest ?? (manifestData as StartMenuManifest));
+  let open = false;
+
+  return {
+    open() {
+      open = true;
+    },
+    close() {
+      open = false;
+    },
+    toggle() {
+      open = !open;
+    },
+    isOpen() {
+      return open;
+    },
+    getSections() {
+      return manifest.sections.map((section) => ({ ...section, items: section.items.map(cloneItem) }));
+    },
+    getRecentDocuments() {
+      return options.recentDocuments.list();
+    },
+    getMenuSchema(sectionId) {
+      const section = manifest.sections.find((entry) => entry.id === sectionId);
+      if (!section) {
+        throw new Error(`Unknown start menu section ${sectionId}`);
+      }
+      return toMenuSchema(section);
+    },
+    search(query) {
+      if (!query.trim()) {
+        return [];
+      }
+      const lower = query.toLowerCase();
+      const results: StartMenuSearchResult[] = [];
+      manifest.sections.forEach((section) => {
+        walkItems(section, [section.label], results);
+      });
+      return results.filter((result) => result.label.toLowerCase().includes(lower));
+    },
+  };
+}

--- a/win95sim_v2/src/apps/shell/taskbar/index.ts
+++ b/win95sim_v2/src/apps/shell/taskbar/index.ts
@@ -1,0 +1,127 @@
+import { EventBus } from '@core/kernel/eventBus';
+import { WindowDescriptor, WindowService } from '@services/window';
+
+export type TaskButtonState = 'active' | 'inactive' | 'minimized';
+
+export interface TaskButton {
+  id: string;
+  title: string;
+  state: TaskButtonState;
+  lastActivated: number;
+}
+
+export interface TaskbarOptions {
+  windows: WindowService;
+  bus: EventBus;
+  clock?: () => number;
+}
+
+export interface TaskbarController {
+  listButtons(): TaskButton[];
+  handleWindow(descriptor: WindowDescriptor): void;
+  activateWindow(id: string): void;
+  toggleMinimize(id: string): void;
+}
+
+export function createTaskbarController(options: TaskbarOptions): TaskbarController {
+  const { windows, bus } = options;
+  const now = options.clock ?? (() => Date.now());
+  const buttons = new Map<string, TaskButton>();
+
+  function ensureButton(descriptor: WindowDescriptor) {
+    if (!buttons.has(descriptor.id)) {
+      buttons.set(descriptor.id, {
+        id: descriptor.id,
+        title: descriptor.title,
+        state: descriptor.state === 'minimized' ? 'minimized' : 'inactive',
+        lastActivated: 0,
+      });
+    }
+  }
+
+  function setActive(id: string) {
+    for (const button of buttons.values()) {
+      if (button.id === id) {
+        button.state = 'active';
+        button.lastActivated = now();
+      } else if (button.state !== 'minimized') {
+        button.state = 'inactive';
+      }
+    }
+  }
+
+  windows.bus.on('window:created', ({ descriptor }) => {
+    ensureButton(descriptor);
+    setActive(descriptor.id);
+    bus.emit('taskbar:buttons-changed', listButtons());
+  });
+
+  windows.bus.on('window:updated', ({ descriptor }) => {
+    ensureButton(descriptor);
+    const button = buttons.get(descriptor.id);
+    if (!button) {
+      return;
+    }
+
+    button.title = descriptor.title;
+    if (descriptor.state === 'minimized') {
+      button.state = 'minimized';
+    } else if (descriptor.state === 'maximized') {
+      setActive(descriptor.id);
+    } else if (descriptor.state === 'normal' && windows.getActiveWindow()?.id === descriptor.id) {
+      setActive(descriptor.id);
+    }
+    bus.emit('taskbar:buttons-changed', listButtons());
+  });
+
+  windows.bus.on('window:activated', ({ descriptor }) => {
+    ensureButton(descriptor);
+    setActive(descriptor.id);
+    bus.emit('taskbar:buttons-changed', listButtons());
+  });
+
+  windows.bus.on('window:removed', ({ id }) => {
+    buttons.delete(id);
+    bus.emit('taskbar:buttons-changed', listButtons());
+  });
+
+  function listButtons(): TaskButton[] {
+    return Array.from(buttons.values()).sort((a, b) => a.lastActivated - b.lastActivated);
+  }
+
+  return {
+    listButtons,
+    handleWindow(descriptor) {
+      ensureButton(descriptor);
+      bus.emit('taskbar:buttons-changed', listButtons());
+    },
+    activateWindow(id) {
+      const descriptor = windows.get(id);
+      if (!descriptor) {
+        return;
+      }
+
+      windows.focus(id);
+      setActive(id);
+      bus.emit('taskbar:buttons-changed', listButtons());
+    },
+    toggleMinimize(id) {
+      const descriptor = windows.get(id);
+      if (!descriptor) {
+        return;
+      }
+
+      if (descriptor.state === 'minimized') {
+        windows.update(id, { state: 'normal' });
+        setActive(id);
+      } else {
+        windows.update(id, { state: 'minimized' });
+        const button = buttons.get(id);
+        if (button) {
+          button.state = 'minimized';
+        }
+      }
+      bus.emit('taskbar:buttons-changed', listButtons());
+    },
+  };
+}

--- a/win95sim_v2/src/services/layout/index.ts
+++ b/win95sim_v2/src/services/layout/index.ts
@@ -1,0 +1,148 @@
+import { createEventBus, EventBus } from '@core/kernel/eventBus';
+
+export interface LayoutPosition {
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+}
+
+export interface LayoutSnapshot {
+  surfaceId: string;
+  items: Record<string, LayoutPosition>;
+  gridSize?: number;
+}
+
+export interface LayoutAdapter {
+  load(surfaceId: string): LayoutSnapshot | undefined;
+  save(surfaceId: string, snapshot: LayoutSnapshot): void;
+}
+
+export interface LayoutEvent {
+  surfaceId: string;
+  snapshot: LayoutSnapshot;
+}
+
+export interface LayoutService {
+  bus: EventBus;
+  getSnapshot(surfaceId: string): LayoutSnapshot;
+  setItem(surfaceId: string, itemId: string, position: LayoutPosition, options?: LayoutUpdateOptions): LayoutSnapshot;
+  removeItem(surfaceId: string, itemId: string): LayoutSnapshot;
+  clear(surfaceId: string): LayoutSnapshot;
+  setGridSize(surfaceId: string, size: number): void;
+}
+
+export interface LayoutUpdateOptions {
+  snapToGrid?: boolean;
+}
+
+interface SurfaceState {
+  gridSize: number;
+  items: Map<string, LayoutPosition>;
+}
+
+export interface LayoutServiceOptions {
+  adapter?: LayoutAdapter;
+  defaultGridSize?: number;
+}
+
+const DEFAULT_GRID_SIZE = 24;
+
+function snap(position: LayoutPosition, gridSize: number): LayoutPosition {
+  const round = (value: number) => Math.round(value / gridSize) * gridSize;
+  return {
+    ...position,
+    x: round(position.x),
+    y: round(position.y),
+    width: position.width !== undefined ? round(position.width) : position.width,
+    height: position.height !== undefined ? round(position.height) : position.height,
+  };
+}
+
+function clone(items: Map<string, LayoutPosition>): Record<string, LayoutPosition> {
+  const snapshot: Record<string, LayoutPosition> = {};
+  for (const [id, position] of items) {
+    snapshot[id] = { ...position };
+  }
+  return snapshot;
+}
+
+export function createLayoutService(options: LayoutServiceOptions = {}): LayoutService {
+  const adapter = options.adapter;
+  const defaultGrid = options.defaultGridSize ?? DEFAULT_GRID_SIZE;
+  const surfaces = new Map<string, SurfaceState>();
+  const bus = createEventBus();
+
+  function ensureSurface(surfaceId: string): SurfaceState {
+    let surface = surfaces.get(surfaceId);
+    if (surface) {
+      return surface;
+    }
+
+    const initial = adapter?.load(surfaceId);
+    surface = {
+      gridSize: initial?.gridSize ?? defaultGrid,
+      items: new Map<string, LayoutPosition>(),
+    };
+
+    if (initial) {
+      for (const [id, position] of Object.entries(initial.items)) {
+        if (id === '__gridSize') {
+          continue;
+        }
+        surface.items.set(id, { ...position });
+      }
+    }
+
+    surfaces.set(surfaceId, surface);
+    return surface;
+  }
+
+  function emit(surfaceId: string): LayoutSnapshot {
+    const surface = ensureSurface(surfaceId);
+    const snapshot: LayoutSnapshot = {
+      surfaceId,
+      items: clone(surface.items),
+      gridSize: surface.gridSize,
+    };
+    if (adapter) {
+      adapter.save(surfaceId, snapshot);
+    }
+    bus.emit<LayoutEvent>('layout:updated', { surfaceId, snapshot });
+    return snapshot;
+  }
+
+  return {
+    bus,
+    getSnapshot(surfaceId) {
+      const surface = ensureSurface(surfaceId);
+      return {
+        surfaceId,
+        items: clone(surface.items),
+        gridSize: surface.gridSize,
+      };
+    },
+    setItem(surfaceId, itemId, position, options = {}) {
+      const surface = ensureSurface(surfaceId);
+      const shouldSnap = options.snapToGrid ?? true;
+      const next = shouldSnap ? snap(position, surface.gridSize) : { ...position };
+      surface.items.set(itemId, next);
+      return emit(surfaceId);
+    },
+    removeItem(surfaceId, itemId) {
+      const surface = ensureSurface(surfaceId);
+      surface.items.delete(itemId);
+      return emit(surfaceId);
+    },
+    clear(surfaceId) {
+      const surface = ensureSurface(surfaceId);
+      surface.items.clear();
+      return emit(surfaceId);
+    },
+    setGridSize(surfaceId, size) {
+      const surface = ensureSurface(surfaceId);
+      surface.gridSize = size;
+      emit(surfaceId);
+    },
+  };
+}

--- a/win95sim_v2/src/services/recent-documents/index.ts
+++ b/win95sim_v2/src/services/recent-documents/index.ts
@@ -1,0 +1,112 @@
+import { EventBus, createEventBus } from '@core/kernel/eventBus';
+
+export interface RecentDocumentEntry {
+  id: string;
+  title: string;
+  path: string;
+  openedAt: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RecentDocumentsSnapshot {
+  entries: RecentDocumentEntry[];
+}
+
+export interface RecentDocumentsAdapter {
+  load(): RecentDocumentsSnapshot | undefined;
+  save(snapshot: RecentDocumentsSnapshot): void;
+}
+
+export interface RecentDocumentEvent {
+  entry: RecentDocumentEntry;
+  entries: RecentDocumentEntry[];
+}
+
+export interface RecentDocumentsService {
+  bus: EventBus;
+  add(entry: Omit<RecentDocumentEntry, 'openedAt'> & { openedAt?: number }): RecentDocumentEntry;
+  list(): RecentDocumentEntry[];
+  clear(): void;
+}
+
+export interface RecentDocumentsOptions {
+  adapter?: RecentDocumentsAdapter;
+  capacity?: number;
+  clock?: () => number;
+  bus?: EventBus;
+}
+
+const DEFAULT_CAPACITY = 10;
+
+export function createRecentDocumentsService(options: RecentDocumentsOptions = {}): RecentDocumentsService {
+  const adapter = options.adapter;
+  const capacity = options.capacity ?? DEFAULT_CAPACITY;
+  const bus = options.bus ?? createEventBus();
+  const now = options.clock ?? (() => Date.now());
+
+  const entries = new Map<string, RecentDocumentEntry>();
+  const order: string[] = [];
+
+  function loadInitial() {
+    const snapshot = adapter?.load();
+    if (!snapshot) {
+      return;
+    }
+
+    snapshot.entries
+      .slice()
+      .sort((a, b) => b.openedAt - a.openedAt)
+      .forEach((entry) => {
+        entries.set(entry.id, entry);
+        order.push(entry.id);
+      });
+  }
+
+  function emit(entry: RecentDocumentEntry) {
+    const list = listEntries();
+    bus.emit<RecentDocumentEvent>('recent-documents:added', { entry, entries: list });
+    adapter?.save({ entries: list });
+  }
+
+  function listEntries(): RecentDocumentEntry[] {
+    return order.map((id) => entries.get(id)!).filter(Boolean);
+  }
+
+  loadInitial();
+
+  return {
+    bus,
+    add(entry) {
+      const openedAt = entry.openedAt ?? now();
+      const record: RecentDocumentEntry = { ...entry, openedAt };
+      if (entries.has(record.id)) {
+        const index = order.indexOf(record.id);
+        if (index !== -1) {
+          order.splice(index, 1);
+        }
+      }
+
+      entries.set(record.id, record);
+      order.unshift(record.id);
+
+      while (order.length > capacity) {
+        const removed = order.pop();
+        if (removed) {
+          entries.delete(removed);
+        }
+      }
+
+      emit(record);
+      return record;
+    },
+    list() {
+      return listEntries();
+    },
+    clear() {
+      entries.clear();
+      order.splice(0, order.length);
+      adapter?.save({ entries: [] });
+      bus.emit('recent-documents:cleared', { entries: [] });
+    },
+  };
+}

--- a/win95sim_v2/src/ui/menus/index.ts
+++ b/win95sim_v2/src/ui/menus/index.ts
@@ -1,0 +1,114 @@
+import { createEventBus, EventBus } from '@core/kernel/eventBus';
+
+export type MenuItemType = 'command' | 'separator' | 'submenu';
+
+export interface MenuCommandContext {
+  source?: string;
+  data?: Record<string, unknown>;
+}
+
+export interface MenuCommand {
+  id: string;
+  label: string;
+  accelerator?: string;
+  run(context: MenuCommandContext): void;
+}
+
+export interface MenuCommandRegistry {
+  bus: EventBus;
+  register(command: MenuCommand): void;
+  unregister(id: string): void;
+  execute(id: string, context?: MenuCommandContext): void;
+  get(id: string): MenuCommand | undefined;
+  list(): MenuCommand[];
+}
+
+export interface MenuSchemaItem {
+  id: string;
+  type?: MenuItemType;
+  label?: string;
+  accelerator?: string;
+  command?: string;
+  children?: MenuSchemaItem[];
+  items?: MenuSchemaItem[];
+}
+
+export interface MenuSchema {
+  id: string;
+  items: MenuSchemaItem[];
+}
+
+export interface RealizedMenuItem {
+  id: string;
+  type: MenuItemType;
+  label?: string;
+  accelerator?: string;
+  command?: string;
+  children?: RealizedMenuItem[];
+}
+
+export interface RealizedMenu {
+  id: string;
+  items: RealizedMenuItem[];
+  execute(commandId: string, context?: MenuCommandContext): void;
+}
+
+export function createMenuCommandRegistry(): MenuCommandRegistry {
+  const commands = new Map<string, MenuCommand>();
+  const bus = createEventBus();
+
+  return {
+    bus,
+    register(command) {
+      if (commands.has(command.id)) {
+        throw new Error(`Command ${command.id} already registered`);
+      }
+      commands.set(command.id, command);
+      bus.emit('menu:command-registered', { command });
+    },
+    unregister(id) {
+      if (commands.delete(id)) {
+        bus.emit('menu:command-unregistered', { id });
+      }
+    },
+    execute(id, context = {}) {
+      const command = commands.get(id);
+      if (!command) {
+        throw new Error(`Unknown command ${id}`);
+      }
+      command.run({ source: context.source, data: context.data ?? {} });
+      bus.emit('menu:command-executed', { id, context });
+    },
+    get(id) {
+      return commands.get(id);
+    },
+    list() {
+      return Array.from(commands.values());
+    },
+  };
+}
+
+function normalizeItem(item: MenuSchemaItem): RealizedMenuItem {
+  const children = item.children ?? item.items;
+  const type: MenuItemType = item.type ?? (children && children.length ? 'submenu' : 'command');
+  return {
+    id: item.id,
+    type,
+    label: item.label,
+    accelerator: item.accelerator,
+    command: item.command,
+    children: children?.map(normalizeItem),
+  };
+}
+
+export function realizeMenu(schema: MenuSchema, registry: MenuCommandRegistry): RealizedMenu {
+  const items = schema.items.map(normalizeItem);
+
+  return {
+    id: schema.id,
+    items,
+    execute(commandId, context = {}) {
+      registry.execute(commandId, context);
+    },
+  };
+}

--- a/win95sim_v2/tests/phase03-shell.test.js
+++ b/win95sim_v2/tests/phase03-shell.test.js
@@ -1,11 +1,215 @@
 const test = require('node:test');
+const assert = require('node:assert/strict');
 
-// Placeholder suite for the command shell and scripting runtime.
+const { loadModule } = require('./helpers/loadModule');
 
-test('command shell executes built-in commands', (t) => {
-  t.todo('wire to process service once Phase 03 begins');
+function createMemoryAdapter() {
+  let snapshot;
+  const saves = [];
+  return {
+    load() {
+      return snapshot;
+    },
+    save(surfaceId, next) {
+      snapshot = JSON.parse(JSON.stringify(next));
+      saves.push(snapshot);
+    },
+    read() {
+      return snapshot;
+    },
+    history() {
+      return saves.slice();
+    },
+  };
+}
+
+test('desktop module persists layout positions and selection state', () => {
+  const { createLayoutService } = loadModule('src/services/layout/index.ts');
+  const { createDesktopModule } = loadModule('src/apps/shell/desktop/index.ts');
+
+  const adapter = createMemoryAdapter();
+  const layout = createLayoutService({ adapter, defaultGridSize: 32 });
+
+  const entries = [
+    { id: 'desktop/computer', title: 'My Computer', resource: '::desktop/computer', type: 'folder' },
+    { id: 'desktop/trash', title: 'Recycle Bin', resource: '::desktop/trash', type: 'folder' },
+    { id: 'desktop/notepad', title: 'Notepad', resource: '::desktop/notepad.lnk', type: 'shortcut' },
+  ];
+
+  let renameLog = null;
+  const desktop = createDesktopModule({
+    layout,
+    resolveEntries: () => entries,
+    onRename: (entry, nextTitle) => {
+      renameLog = { id: entry.id, nextTitle };
+      entry.title = nextTitle;
+    },
+  });
+
+  const initial = desktop.list();
+  assert.equal(initial.length, 3);
+  initial.forEach((icon, index) => {
+    assert.ok(icon.position.x % 32 === 0, 'expected x to align to grid');
+    assert.ok(icon.position.y % 32 === 0, 'expected y to align to grid');
+    assert.equal(icon.selected, false);
+    assert.ok(icon.position.y >= 0, 'expected non-negative coordinates');
+  });
+
+  desktop.move('desktop/notepad', { x: 45, y: 83 });
+  const snapshot = layout.getSnapshot('::desktop');
+  const notepadPosition = snapshot.items['desktop/notepad'];
+  assert.equal(notepadPosition.x, 32);
+  assert.equal(notepadPosition.y, 96);
+
+  desktop.setSelection(['desktop/computer', 'desktop/notepad']);
+  assert.deepEqual(desktop.getSelection().sort(), ['desktop/computer', 'desktop/notepad']);
+  desktop.clearSelection();
+  assert.deepEqual(desktop.getSelection(), []);
+
+  const renamed = desktop.rename('desktop/notepad', 'Notepad (1)');
+  assert.equal(renamed.title, 'Notepad (1)');
+  assert.deepEqual(renameLog, { id: 'desktop/notepad', nextTitle: 'Notepad (1)' });
+
+  desktop.arrange();
+  const arranged = layout.getSnapshot('::desktop');
+  const persisted = adapter.read();
+  assert.ok(persisted);
+  const persistedItems = persisted.items ?? persisted;
+  const arrangedIds = Object.keys(arranged.items);
+  assert.deepEqual(arrangedIds.sort(), Object.keys(persistedItems).sort());
+  arrangedIds.forEach((id) => {
+    assert.equal(arranged.items[id].x, persistedItems[id].x);
+    assert.equal(arranged.items[id].y, persistedItems[id].y);
+  });
+  assert.ok(adapter.history().length > 0);
 });
 
-test('scripting engine exposes automation API', (t) => {
-  t.todo('assert compatibility with legacy macros');
+test('taskbar controller mirrors window lifecycle events', () => {
+  const { createTaskbarController } = loadModule('src/apps/shell/taskbar/index.ts');
+  const { createWindowService } = loadModule('src/services/window/index.ts');
+  const { createEventBus } = loadModule('src/core/kernel/eventBus.ts');
+
+  const windows = createWindowService();
+  const bus = createEventBus();
+  let clock = 0;
+  const taskbar = createTaskbarController({
+    windows,
+    bus,
+    clock: () => ++clock,
+  });
+
+  const events = [];
+  bus.on('taskbar:buttons-changed', (payload) => events.push(payload));
+
+  const alpha = windows.create({
+    id: 'apps/alpha',
+    title: 'Alpha',
+    bounds: { x: 10, y: 10, width: 200, height: 140 },
+  });
+  windows.create({
+    id: 'apps/beta',
+    title: 'Beta',
+    bounds: { x: 30, y: 30, width: 200, height: 140 },
+  });
+
+  assert.equal(events.length >= 2, true, 'expected button change events');
+  let buttons = taskbar.listButtons();
+  assert.equal(buttons.length, 2);
+  const activeWindow = windows.getActiveWindow();
+  assert.ok(activeWindow);
+  const active = buttons.find((button) => button.id === activeWindow.id);
+  assert.equal(active.state, 'active');
+
+  windows.update(alpha.id, { state: 'minimized' });
+  buttons = taskbar.listButtons();
+  assert.equal(buttons.find((btn) => btn.id === alpha.id).state, 'minimized');
+
+  taskbar.toggleMinimize(alpha.id);
+  assert.equal(taskbar.listButtons().find((btn) => btn.id === alpha.id).state, 'active');
+
+  taskbar.activateWindow('apps/beta');
+  buttons = taskbar.listButtons();
+  const beta = buttons.find((btn) => btn.id === 'apps/beta');
+  assert.equal(beta.state, 'active');
+  assert.ok(beta.lastActivated > 0);
+
+  windows.remove(alpha.id);
+  assert.equal(taskbar.listButtons().length, 1);
+});
+
+test('start menu exposes manifest sections and recent documents', () => {
+  const { createStartMenuModel } = loadModule('src/apps/shell/start-menu/index.ts');
+  const { createRecentDocumentsService } = loadModule('src/services/recent-documents/index.ts');
+
+  const recentDocuments = createRecentDocumentsService({ capacity: 5, clock: (() => {
+    let value = 0;
+    return () => (value += 1);
+  })() });
+
+  const startMenu = createStartMenuModel({ recentDocuments });
+  const sections = startMenu.getSections();
+  assert.ok(sections.some((section) => section.id === 'programs'));
+  assert.ok(sections.some((section) => section.id === 'documents'));
+
+  recentDocuments.add({ id: 'doc-1', title: 'Budget.xls', path: 'C:/Docs/Budget.xls' });
+  recentDocuments.add({ id: 'doc-2', title: 'Letter.doc', path: 'C:/Docs/Letter.doc' });
+  assert.deepEqual(startMenu.getRecentDocuments().map((entry) => entry.id), ['doc-2', 'doc-1']);
+
+  const schema = startMenu.getMenuSchema('programs');
+  const accessories = schema.items.find((item) => item.id === 'programs/accessories');
+  assert.ok(accessories);
+  assert.equal(accessories.children.some((child) => child.id.endsWith('notepad')), true);
+
+  const results = startMenu.search('paint');
+  assert.ok(results.length >= 1);
+  assert.equal(results[0].path.includes('Programs'), true);
+  assert.equal(results[0].command, 'shell:start:paint');
+
+  assert.equal(startMenu.isOpen(), false);
+  startMenu.open();
+  assert.equal(startMenu.isOpen(), true);
+  startMenu.toggle();
+  assert.equal(startMenu.isOpen(), false);
+});
+
+test('menu command registry composes declarative menu schemas', () => {
+  const { createMenuCommandRegistry, realizeMenu } = loadModule('src/ui/menus/index.ts');
+
+  const registry = createMenuCommandRegistry();
+  const executed = [];
+
+  registry.register({
+    id: 'desktop:refresh',
+    label: 'Refresh',
+    run: (context) => executed.push(context.source),
+  });
+
+  const schema = {
+    id: 'desktop-context',
+    items: [
+      { id: 'refresh', label: 'Refresh', command: 'desktop:refresh' },
+      { id: 'separator-1', type: 'separator' },
+      {
+        id: 'new',
+        label: 'New',
+        items: [{ id: 'new/folder', label: 'Folder', command: 'desktop:new-folder' }],
+      },
+    ],
+  };
+
+  const menu = realizeMenu(schema, registry);
+  menu.execute('desktop:refresh', { source: 'desktop' });
+
+  assert.deepEqual(executed, ['desktop']);
+  assert.throws(() => registry.execute('unknown'), /unknown command/i);
+
+  registry.register({
+    id: 'desktop:new-folder',
+    label: 'Folder',
+    run: () => executed.push('new-folder'),
+  });
+
+  assert.equal(menu.items.find((item) => item.id === 'new').children.length, 1);
+  menu.execute('desktop:new-folder');
+  assert.ok(executed.includes('new-folder'));
 });

--- a/win95sim_v2/tsconfig.json
+++ b/win95sim_v2/tsconfig.json
@@ -16,7 +16,7 @@
       "@shell/*": ["shell/*"],
       "@features/*": ["features/*"]
     },
-    "types": ["./src/types/css"],
+    "types": ["./src/types/css", "./types/shell"],
     "resolveJsonModule": true
   },
   "include": ["src/**/*", "tests/helpers/**/*.ts"],

--- a/win95sim_v2/types/shell/index.d.ts
+++ b/win95sim_v2/types/shell/index.d.ts
@@ -1,0 +1,43 @@
+declare namespace Win95SimShell {
+  interface ShellWidgetContext {
+    bus: {
+      emit(type: string, payload?: unknown): void;
+      on(type: string, handler: (payload: unknown) => void): () => void;
+    };
+  }
+
+  interface ShellWidgetInstance {
+    mount(container: HTMLElement): void;
+    unmount(): void;
+  }
+
+  interface ShellWidgetRegistration {
+    id: string;
+    title: string;
+    mount(context: ShellWidgetContext): ShellWidgetInstance;
+  }
+
+  interface TrayProvider {
+    id: string;
+    mount(container: HTMLElement): void;
+    unmount(): void;
+  }
+
+  interface StartMenuContribution {
+    id: string;
+    section: string;
+    items: Array<{
+      id: string;
+      label: string;
+      command: string;
+    }>;
+  }
+
+  interface ShellAPI {
+    registerShellWidget(widget: ShellWidgetRegistration): void;
+    registerTrayProvider(provider: TrayProvider): void;
+    registerStartMenuContribution(extension: StartMenuContribution): void;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add layout persistence and recent document services together with a reusable menu command registry for shell extensions
- implement desktop, taskbar, and start menu controllers backed by the new data manifest and services
- document the published shell command identifiers and declare shell extension point typings for downstream teams

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f65c67911c83298df6e77ae9814442