### PR TITLE
Add Navigator session services and supporting utilities

### DIFF
--- a/win95sim_v2/.gitignore
+++ b/win95sim_v2/.gitignore
@@ -3,3 +3,5 @@ dist/
 tests/.cache/
 .DS_Store
 npm-debug.log*
+!src/services/downloads/
+!src/services/downloads/**

--- a/win95sim_v2/docs/navigator-extension-guide.md
+++ b/win95sim_v2/docs/navigator-extension-guide.md
@@ -1,0 +1,90 @@
+# Navigator Extension Guide
+
+Navigator exposes a set of high level services so add-ons can plug into the
+browser without patching core files. The APIs described here are stable for the
+Phase 05 release and align with the module contracts documented in
+`docs/module-apis-v2.md`.
+
+## Module overview
+
+- **Module ID:** `apps/internet/navigator`
+- **Entry point:** `src/apps/internet/navigator/index.ts`
+- **Layer:** `apps/`
+- **Dependencies:**
+  - `@core/kernel/eventBus`
+  - `@services/settings`
+  - `@services/network`
+  - `@services/security`
+  - `@services/downloads`
+
+Extensions should depend only on the public exports from
+`src/apps/internet/navigator/index.ts`. Direct imports from nested folders are
+not considered public API and may change without notice.
+
+## Session management
+
+```ts
+import { createNavigatorSession } from '@apps/internet/navigator';
+```
+
+`createNavigatorSession` accepts a `SettingsService` and returns a controller for
+managing the active tab. The session persists navigation history and per-tab
+mode preferences using the `navigator.session` namespace in the settings
+service.
+
+### Events
+
+The session exposes an `EventBus` that emits:
+
+- `navigator:navigated` – fired whenever the active URL changes
+- `navigator:mode-changed` – fired when the tab switches between iframe, reader,
+  or proxy mode
+
+Subscribers receive a snapshot containing the active tab state. Snapshots are
+immutable copies so listeners can safely cache them.
+
+## Bookmarks store
+
+```ts
+import { createBookmarkStore } from '@apps/internet/navigator';
+```
+
+The bookmark store persists entries under `navigator.bookmarks`. It supports
+adding, removing, and reordering bookmarks. Consumers should listen to the
+`bookmarks:changed` event on the store’s bus to keep UI in sync.
+
+## Security & sanitization
+
+Reader mode and View Source both delegate to
+`@services/security/sanitizer.sanitizeHtml`. The sanitizer removes script tags,
+inline event handlers, and disallowed URL protocols (only `http`, `https`,
+`data`, and `mailto` are allowed by default). Extensions should reuse this helper
+when displaying third-party HTML fragments.
+
+## Networking helpers
+
+Navigator ships a configurable iframe policy and proxy validation helpers under
+`@services/network`:
+
+- `createIframePolicy` returns sandbox attributes for iframe elements and
+  validates target URLs.
+- `validateProxyUrl` and `buildProxiedUrl` help extensions integrate with user
+  configured HTTP(S) proxies.
+
+## Downloads
+
+The download manager in `@services/downloads` coordinates fetches and persistence
+into the virtual file system (VFS). Extensions enqueue downloads through
+`createDownloadManager` and listen for lifecycle events (`download:started`,
+`download:completed`, `download:failed`) on the returned event bus.
+
+## Compatibility notes
+
+- All APIs are implemented in TypeScript and compiled for tests. Extensions
+  should consume the JavaScript emitted by the build pipeline.
+- Network-related helpers intentionally reject unsupported protocols to prevent
+  security regressions. Validate user input before invoking downloads or proxy
+  utilities.
+- The module registry manifest is provided in
+  `src/apps/internet/navigator/module.json`. Extensions should reference the
+  module ID when registering with the shell or Start menu manifests.

--- a/win95sim_v2/src/apps/internet/navigator/index.ts
+++ b/win95sim_v2/src/apps/internet/navigator/index.ts
@@ -1,0 +1,13 @@
+export {
+  createNavigatorSession,
+  type NavigatorSession,
+  type NavigatorTabState,
+  type NavigatorSessionSnapshot,
+  type NavigatorMode,
+} from './state/session';
+
+export {
+  createBookmarkStore,
+  type BookmarkStore,
+  type BookmarkEntry,
+} from './stores/bookmarks';

--- a/win95sim_v2/src/apps/internet/navigator/module.json
+++ b/win95sim_v2/src/apps/internet/navigator/module.json
@@ -1,0 +1,6 @@
+{
+  "id": "apps/internet/navigator",
+  "name": "Navigator",
+  "version": "2.0.0",
+  "entry": "./index.ts"
+}

--- a/win95sim_v2/src/apps/internet/navigator/state/session.ts
+++ b/win95sim_v2/src/apps/internet/navigator/state/session.ts
@@ -1,0 +1,182 @@
+import { createEventBus, EventBus } from '@core/kernel/eventBus';
+import { SettingsService } from '@services/settings';
+
+export type NavigatorMode = 'iframe' | 'reader' | 'proxy';
+
+export interface NavigatorTabState {
+  id: string;
+  url: string;
+  mode: NavigatorMode;
+  history: string[];
+  historyIndex: number;
+}
+
+export interface NavigatorSessionSnapshot {
+  activeTab: NavigatorTabState;
+}
+
+export interface NavigatorSessionOptions {
+  settings: SettingsService;
+  homeUrl?: string;
+  storageKey?: string;
+}
+
+export interface NavigatorSession {
+  getSnapshot(): NavigatorSessionSnapshot;
+  getActiveTab(): NavigatorTabState;
+  navigate(url: string): NavigatorTabState;
+  goBack(): NavigatorTabState | undefined;
+  goForward(): NavigatorTabState | undefined;
+  setMode(mode: NavigatorMode): NavigatorTabState;
+  bus: EventBus;
+}
+
+interface PersistedState {
+  activeTab: NavigatorTabState;
+}
+
+const DEFAULT_HOME_URL = 'about:blank';
+const DEFAULT_STORAGE_KEY = 'navigator.session';
+
+function createInitialTab(homeUrl: string): NavigatorTabState {
+  return {
+    id: 'tab-1',
+    url: homeUrl,
+    mode: 'iframe',
+    history: [homeUrl],
+    historyIndex: 0,
+  };
+}
+
+function cloneTab(tab: NavigatorTabState): NavigatorTabState {
+  return {
+    ...tab,
+    history: [...tab.history],
+  };
+}
+
+function restoreState(settings: SettingsService, storageKey: string, homeUrl: string): NavigatorTabState {
+  const raw = settings.get(storageKey);
+  if (typeof raw !== 'string') {
+    return createInitialTab(homeUrl);
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as PersistedState;
+    if (parsed && parsed.activeTab && parsed.activeTab.url) {
+      const tab = parsed.activeTab;
+      return {
+        ...tab,
+        history: Array.isArray(tab.history) && tab.history.length > 0 ? [...tab.history] : [tab.url],
+        historyIndex: typeof tab.historyIndex === 'number' ? tab.historyIndex : tab.history.length - 1,
+        mode: tab.mode ?? 'iframe',
+        id: tab.id ?? 'tab-1',
+      };
+    }
+  } catch (error) {
+    // fall through to default state
+  }
+
+  return createInitialTab(homeUrl);
+}
+
+export function createNavigatorSession(options: NavigatorSessionOptions): NavigatorSession {
+  const { settings } = options;
+  const homeUrl = options.homeUrl ?? DEFAULT_HOME_URL;
+  const storageKey = options.storageKey ?? DEFAULT_STORAGE_KEY;
+
+  const bus = createEventBus();
+  let activeTab = restoreState(settings, storageKey, homeUrl);
+
+  function persist() {
+    const snapshot: PersistedState = {
+      activeTab: cloneTab(activeTab),
+    };
+    settings.set(storageKey, JSON.stringify(snapshot));
+  }
+
+  function emit(type: string) {
+    bus.emit(type, { snapshot: getSnapshot() });
+  }
+
+  function getSnapshot(): NavigatorSessionSnapshot {
+    return {
+      activeTab: cloneTab(activeTab),
+    };
+  }
+
+  function navigate(url: string): NavigatorTabState {
+    const nextHistory = activeTab.history.slice(0, activeTab.historyIndex + 1);
+    nextHistory.push(url);
+
+    activeTab = {
+      ...activeTab,
+      url,
+      history: nextHistory,
+      historyIndex: nextHistory.length - 1,
+    };
+
+    persist();
+    emit('navigator:navigated');
+    return cloneTab(activeTab);
+  }
+
+  function goBack(): NavigatorTabState | undefined {
+    if (activeTab.historyIndex === 0) {
+      return undefined;
+    }
+
+    activeTab = {
+      ...activeTab,
+      historyIndex: activeTab.historyIndex - 1,
+      url: activeTab.history[activeTab.historyIndex - 1],
+    };
+
+    persist();
+    emit('navigator:navigated');
+    return cloneTab(activeTab);
+  }
+
+  function goForward(): NavigatorTabState | undefined {
+    if (activeTab.historyIndex >= activeTab.history.length - 1) {
+      return undefined;
+    }
+
+    activeTab = {
+      ...activeTab,
+      historyIndex: activeTab.historyIndex + 1,
+      url: activeTab.history[activeTab.historyIndex + 1],
+    };
+
+    persist();
+    emit('navigator:navigated');
+    return cloneTab(activeTab);
+  }
+
+  function setMode(mode: NavigatorMode): NavigatorTabState {
+    if (activeTab.mode === mode) {
+      return cloneTab(activeTab);
+    }
+
+    activeTab = {
+      ...activeTab,
+      mode,
+    };
+
+    persist();
+    emit('navigator:mode-changed');
+    return cloneTab(activeTab);
+  }
+
+  return {
+    getSnapshot,
+    getActiveTab() {
+      return cloneTab(activeTab);
+    },
+    navigate,
+    goBack,
+    goForward,
+    setMode,
+    bus,
+  };
+}

--- a/win95sim_v2/src/apps/internet/navigator/stores/bookmarks.ts
+++ b/win95sim_v2/src/apps/internet/navigator/stores/bookmarks.ts
@@ -1,0 +1,130 @@
+import { createEventBus, EventBus } from '@core/kernel/eventBus';
+import { SettingsService } from '@services/settings';
+
+export interface BookmarkEntry {
+  id: string;
+  title: string;
+  url: string;
+  createdAt: number;
+}
+
+export interface BookmarkEvent {
+  bookmarks: BookmarkEntry[];
+}
+
+export interface BookmarkStoreOptions {
+  settings: SettingsService;
+  storageKey?: string;
+  idGenerator?: () => string;
+}
+
+export interface BookmarkStore {
+  list(): BookmarkEntry[];
+  add(title: string, url: string): BookmarkEntry;
+  remove(id: string): void;
+  reorder(order: string[]): void;
+  bus: EventBus;
+}
+
+const DEFAULT_STORAGE_KEY = 'navigator.bookmarks';
+
+let bookmarkCounter = 0;
+
+function defaultIdGenerator(): string {
+  bookmarkCounter += 1;
+  return `bookmark-${bookmarkCounter}`;
+}
+
+function loadBookmarks(settings: SettingsService, storageKey: string): BookmarkEntry[] {
+  const raw = settings.get(storageKey);
+  if (typeof raw !== 'string') {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as BookmarkEntry[];
+    if (Array.isArray(parsed)) {
+      return parsed.map((entry) => ({
+        ...entry,
+        createdAt: entry.createdAt ?? Date.now(),
+      }));
+    }
+  } catch (error) {
+    // Ignore malformed payloads.
+  }
+
+  return [];
+}
+
+export function createBookmarkStore(options: BookmarkStoreOptions): BookmarkStore {
+  const { settings } = options;
+  const storageKey = options.storageKey ?? DEFAULT_STORAGE_KEY;
+  const idGenerator = options.idGenerator ?? defaultIdGenerator;
+
+  const bus = createEventBus();
+  let bookmarks = loadBookmarks(settings, storageKey);
+
+  function emit() {
+    bus.emit<BookmarkEvent>('bookmarks:changed', { bookmarks: list() });
+  }
+
+  function persist() {
+    settings.set(storageKey, JSON.stringify(bookmarks));
+  }
+
+  function list(): BookmarkEntry[] {
+    return bookmarks.map((entry) => ({ ...entry }));
+  }
+
+  function add(title: string, url: string): BookmarkEntry {
+    const entry: BookmarkEntry = {
+      id: idGenerator(),
+      title,
+      url,
+      createdAt: Date.now(),
+    };
+    bookmarks = [...bookmarks, entry];
+    persist();
+    emit();
+    return { ...entry };
+  }
+
+  function remove(id: string) {
+    const next = bookmarks.filter((entry) => entry.id !== id);
+    if (next.length === bookmarks.length) {
+      return;
+    }
+    bookmarks = next;
+    persist();
+    emit();
+  }
+
+  function reorder(order: string[]) {
+    const orderSet = new Set(order);
+    const reordered: BookmarkEntry[] = [];
+    order.forEach((id) => {
+      const match = bookmarks.find((entry) => entry.id === id);
+      if (match) {
+        reordered.push(match);
+      }
+    });
+
+    bookmarks.forEach((entry) => {
+      if (!orderSet.has(entry.id)) {
+        reordered.push(entry);
+      }
+    });
+
+    bookmarks = reordered;
+    persist();
+    emit();
+  }
+
+  return {
+    list,
+    add,
+    remove,
+    reorder,
+    bus,
+  };
+}

--- a/win95sim_v2/src/apps/tools/view-source/index.ts
+++ b/win95sim_v2/src/apps/tools/view-source/index.ts
@@ -1,0 +1,18 @@
+import { sanitizeHtml, SanitizeResult, SanitizerConfig } from '@services/security/sanitizer';
+
+export interface ViewSourceOptions {
+  sanitizerConfig?: SanitizerConfig;
+}
+
+export interface ViewSourceResult extends SanitizeResult {
+  lines: string[];
+}
+
+export function renderSourceDocument(source: string, options: ViewSourceOptions = {}): ViewSourceResult {
+  const result = sanitizeHtml(source, options.sanitizerConfig);
+  const lines = result.html.split(/\r?\n/u);
+  return {
+    ...result,
+    lines,
+  };
+}

--- a/win95sim_v2/src/apps/tools/view-source/module.json
+++ b/win95sim_v2/src/apps/tools/view-source/module.json
@@ -1,0 +1,6 @@
+{
+  "id": "apps/tools/view-source",
+  "name": "View Source",
+  "version": "2.0.0",
+  "entry": "./index.ts"
+}

--- a/win95sim_v2/src/services/downloads/index.ts
+++ b/win95sim_v2/src/services/downloads/index.ts
@@ -1,0 +1,125 @@
+import { createEventBus, EventBus } from '@core/kernel/eventBus';
+
+export type DownloadStatus = 'queued' | 'downloading' | 'completed' | 'failed';
+
+export interface DownloadRequest {
+  id?: string;
+  url: string;
+  filename: string;
+  mimeType?: string;
+}
+
+export interface DownloadRecord extends DownloadRequest {
+  id: string;
+  status: DownloadStatus;
+  receivedBytes: number;
+  totalBytes?: number;
+  startedAt: number;
+  completedAt?: number;
+  error?: string;
+}
+
+export interface DownloadResponse {
+  data: ArrayBuffer | Uint8Array | string;
+  totalBytes?: number;
+}
+
+export interface DownloadManagerOptions {
+  fetchResource?: (request: DownloadRequest) => Promise<DownloadResponse>;
+  saveFile?: (record: DownloadRecord, data: Uint8Array) => Promise<void> | void;
+  idGenerator?: () => string;
+}
+
+export interface DownloadEvent {
+  record: DownloadRecord;
+}
+
+export interface DownloadManager {
+  start(request: DownloadRequest): Promise<DownloadRecord>;
+  get(id: string): DownloadRecord | undefined;
+  list(): DownloadRecord[];
+  bus: EventBus;
+}
+
+let autoIncrement = 0;
+
+function defaultIdGenerator(): string {
+  autoIncrement += 1;
+  return `download-${autoIncrement}`;
+}
+
+function coerceToUint8Array(data: ArrayBuffer | Uint8Array | string): Uint8Array {
+  if (typeof data === 'string') {
+    return new TextEncoder().encode(data);
+  }
+
+  if (data instanceof Uint8Array) {
+    return data;
+  }
+
+  return new Uint8Array(data);
+}
+
+export function createDownloadManager(options: DownloadManagerOptions = {}): DownloadManager {
+  const fetchResource = options.fetchResource ?? (async () => ({ data: new Uint8Array() }));
+  const saveFile = options.saveFile ?? (() => {});
+  const idGenerator = options.idGenerator ?? defaultIdGenerator;
+
+  const bus = createEventBus();
+  const records = new Map<string, DownloadRecord>();
+
+  function emit(type: string, record: DownloadRecord) {
+    bus.emit<DownloadEvent>(type, { record });
+  }
+
+  async function start(request: DownloadRequest): Promise<DownloadRecord> {
+    const id = request.id ?? idGenerator();
+    const record: DownloadRecord = {
+      ...request,
+      id,
+      status: 'downloading',
+      receivedBytes: 0,
+      totalBytes: undefined,
+      startedAt: Date.now(),
+    };
+    records.set(id, record);
+    emit('download:started', { ...record });
+
+    try {
+      const response = await fetchResource(request);
+      const buffer = coerceToUint8Array(response.data);
+      const updated: DownloadRecord = {
+        ...record,
+        status: 'completed',
+        receivedBytes: buffer.byteLength,
+        totalBytes: response.totalBytes ?? buffer.byteLength,
+        completedAt: Date.now(),
+      };
+      records.set(id, updated);
+      emit('download:completed', { ...updated });
+      await Promise.resolve(saveFile(updated, buffer));
+      return updated;
+    } catch (error) {
+      const updated: DownloadRecord = {
+        ...record,
+        status: 'failed',
+        error: error instanceof Error ? error.message : String(error),
+        completedAt: Date.now(),
+      };
+      records.set(id, updated);
+      emit('download:failed', { ...updated });
+      throw updated;
+    }
+  }
+
+  return {
+    start,
+    get(id) {
+      return records.get(id);
+    },
+    list() {
+      return Array.from(records.values()).sort((a, b) => a.startedAt - b.startedAt);
+    },
+    bus,
+  };
+}

--- a/win95sim_v2/src/services/network/iframe-policy.ts
+++ b/win95sim_v2/src/services/network/iframe-policy.ts
@@ -1,0 +1,69 @@
+export interface IframePolicyOptions {
+  allowScripts?: boolean;
+  allowSameOrigin?: boolean;
+  allowPopups?: boolean;
+  allowedProtocols?: string[];
+  blockedHosts?: string[];
+}
+
+export interface IframePolicy {
+  getSandboxFlags(): string[];
+  isUrlAllowed(url: string): boolean;
+  buildAttributes(url: string): Record<string, string>;
+}
+
+const DEFAULT_ALLOWED_PROTOCOLS = ['http', 'https'];
+
+function normalizeHost(host: string): string {
+  return host.toLowerCase();
+}
+
+export function createIframePolicy(options: IframePolicyOptions = {}): IframePolicy {
+  const sandboxFlags = ['allow-forms'];
+  if (options.allowScripts) {
+    sandboxFlags.push('allow-scripts');
+  }
+  if (options.allowSameOrigin) {
+    sandboxFlags.push('allow-same-origin');
+  }
+  if (options.allowPopups) {
+    sandboxFlags.push('allow-popups');
+  }
+
+  const allowedProtocols = options.allowedProtocols ?? DEFAULT_ALLOWED_PROTOCOLS;
+  const blockedHosts = new Set((options.blockedHosts ?? []).map(normalizeHost));
+
+  function isUrlAllowed(target: string): boolean {
+    try {
+      const parsed = new URL(target);
+      const protocol = parsed.protocol.replace(/:$/, '').toLowerCase();
+      if (!allowedProtocols.includes(protocol)) {
+        return false;
+      }
+
+      if (blockedHosts.has(normalizeHost(parsed.host))) {
+        return false;
+      }
+
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  return {
+    getSandboxFlags() {
+      return [...sandboxFlags];
+    },
+    isUrlAllowed(url) {
+      return isUrlAllowed(url);
+    },
+    buildAttributes(url) {
+      return {
+        sandbox: sandboxFlags.join(' '),
+        src: isUrlAllowed(url) ? url : 'about:blank',
+        referrerpolicy: 'strict-origin-when-cross-origin',
+      };
+    },
+  };
+}

--- a/win95sim_v2/src/services/network/index.ts
+++ b/win95sim_v2/src/services/network/index.ts
@@ -1,0 +1,12 @@
+export {
+  createIframePolicy,
+  type IframePolicy,
+  type IframePolicyOptions,
+} from './iframe-policy';
+
+export {
+  validateProxyUrl,
+  buildProxiedUrl,
+  isProxyEnabled,
+  type ProxyValidationResult,
+} from './proxy';

--- a/win95sim_v2/src/services/network/proxy.ts
+++ b/win95sim_v2/src/services/network/proxy.ts
@@ -1,0 +1,56 @@
+export interface ProxyValidationResult {
+  valid: boolean;
+  normalized?: string;
+  reason?: string;
+}
+
+function ensureTrailingSlash(url: URL): URL {
+  if (!url.pathname.endsWith('/')) {
+    url.pathname = `${url.pathname}/`;
+  }
+  return url;
+}
+
+export function validateProxyUrl(input: string): ProxyValidationResult {
+  if (!input || input.trim().length === 0) {
+    return { valid: false, reason: 'empty' };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(input);
+  } catch (error) {
+    return { valid: false, reason: 'invalid-url' };
+  }
+
+  const protocol = parsed.protocol.replace(/:$/, '').toLowerCase();
+  if (protocol !== 'http' && protocol !== 'https') {
+    return { valid: false, reason: 'invalid-protocol' };
+  }
+
+  if (parsed.username || parsed.password) {
+    return { valid: false, reason: 'credentials-not-allowed' };
+  }
+
+  ensureTrailingSlash(parsed);
+
+  return { valid: true, normalized: parsed.toString() };
+}
+
+export function buildProxiedUrl(proxyBase: string, targetUrl: string): string {
+  const validation = validateProxyUrl(proxyBase);
+  if (!validation.valid || !validation.normalized) {
+    throw new Error(`Invalid proxy base: ${validation.reason ?? 'unknown'}`);
+  }
+
+  const encodedTarget = encodeURIComponent(targetUrl);
+  return `${validation.normalized}${encodedTarget}`;
+}
+
+export function isProxyEnabled(proxyBase: string | undefined | null): boolean {
+  if (!proxyBase) {
+    return false;
+  }
+  const result = validateProxyUrl(proxyBase);
+  return result.valid;
+}

--- a/win95sim_v2/src/services/security/sanitizer.ts
+++ b/win95sim_v2/src/services/security/sanitizer.ts
@@ -1,0 +1,89 @@
+export interface SanitizerConfig {
+  /**
+   * Allowed URI schemes for URL-bearing attributes. Relative URLs are always permitted.
+   */
+  allowedSchemes?: string[];
+  /**
+   * Attributes that should be preserved even if they resemble event handlers.
+   */
+  safeEventAttributes?: string[];
+}
+
+export interface SanitizeResult {
+  html: string;
+  removedElements: string[];
+  strippedAttributes: string[];
+  blockedProtocols: string[];
+}
+
+const SCRIPT_TAG_PATTERN = /<script\b[^>]*>[\s\S]*?<\/script>/gi;
+const EVENT_HANDLER_PATTERN = /\son[a-z]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi;
+const ATTRIBUTE_PATTERN = /(href|src|action)\s*=\s*("([^"]*)"|'([^']*)')/gi;
+
+const DEFAULT_ALLOWED_SCHEMES = ['http', 'https', 'data', 'mailto'];
+
+function extractScheme(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('#') || trimmed.startsWith('/')) {
+    return null;
+  }
+
+  const protocolMatch = /^[a-zA-Z][a-zA-Z0-9+.-]*:/u.exec(trimmed);
+  if (!protocolMatch) {
+    return null;
+  }
+
+  return protocolMatch[0].slice(0, -1).toLowerCase();
+}
+
+function shouldPreserveAttribute(attribute: string, safeEventAttributes: string[]): boolean {
+  return safeEventAttributes.some((candidate) => candidate.toLowerCase() === attribute.toLowerCase());
+}
+
+export function sanitizeHtml(input: string, config: SanitizerConfig = {}): SanitizeResult {
+  const allowedSchemes = config.allowedSchemes ?? DEFAULT_ALLOWED_SCHEMES;
+  const safeEventAttributes = config.safeEventAttributes ?? [];
+
+  const removedElements: string[] = [];
+  const strippedAttributes: string[] = [];
+  const blockedProtocols: string[] = [];
+
+  let html = input.replace(SCRIPT_TAG_PATTERN, (match) => {
+    removedElements.push(match);
+    return '';
+  });
+
+  html = html.replace(EVENT_HANDLER_PATTERN, (match) => {
+    const attribute = match.trim().split('=')[0];
+    if (shouldPreserveAttribute(attribute, safeEventAttributes)) {
+      return match;
+    }
+
+    strippedAttributes.push(attribute);
+    return '';
+  });
+
+  html = html.replace(
+    ATTRIBUTE_PATTERN,
+    (match, attr: string, _full: string, doubleValue?: string, singleValue?: string) => {
+      const value = doubleValue ?? singleValue ?? '';
+      const quote = doubleValue !== undefined ? '"' : "'";
+      const scheme = extractScheme(value);
+      if (!scheme || allowedSchemes.includes(scheme)) {
+        return `${attr}=${quote}${value}${quote}`;
+      }
+
+      blockedProtocols.push(`${attr}:${scheme}`);
+      strippedAttributes.push(attr);
+      const safeValue = value.startsWith('/') ? value : '#';
+      return `${attr}=${quote}${safeValue}${quote}`;
+    },
+  );
+
+  return {
+    html,
+    removedElements,
+    strippedAttributes,
+    blockedProtocols,
+  };
+}

--- a/win95sim_v2/tests/phase05-navigator.test.js
+++ b/win95sim_v2/tests/phase05-navigator.test.js
@@ -1,11 +1,137 @@
 const test = require('node:test');
+const assert = require('node:assert');
 
-// Placeholder suite for the Navigator app and networking stack.
+const { loadModule } = require('./helpers/loadModule');
 
-test('navigator loads page manifests through networking service', (t) => {
-  t.todo('mock network requests once service is implemented');
+const navigatorModule = () => loadModule('src/apps/internet/navigator/index.ts');
+const settingsModule = () => loadModule('src/services/settings/index.ts');
+const sanitizerModule = () => loadModule('src/services/security/sanitizer.ts');
+const networkProxyModule = () => loadModule('src/services/network/proxy.ts');
+const networkIframeModule = () => loadModule('src/services/network/iframe-policy.ts');
+const downloadsModule = () => loadModule('src/services/downloads/index.ts');
+
+function createSettings(initial = {}) {
+  const { createSettingsService } = settingsModule();
+  return createSettingsService(initial);
+}
+
+test('navigator session persists tab mode and history', () => {
+  const { createNavigatorSession } = navigatorModule();
+
+  const settings = createSettings();
+  const session = createNavigatorSession({
+    settings,
+    homeUrl: 'https://initial.example',
+  });
+
+  assert.strictEqual(session.getActiveTab().mode, 'iframe');
+  session.setMode('reader');
+
+  session.navigate('https://example.org/docs');
+  session.goBack();
+  const forward = session.goForward();
+  assert.ok(forward);
+  assert.strictEqual(forward.url, 'https://example.org/docs');
+
+  const restored = createNavigatorSession({ settings });
+  assert.strictEqual(restored.getActiveTab().mode, 'reader');
+  assert.strictEqual(restored.getActiveTab().url, 'https://example.org/docs');
 });
 
-test('navigator respects security sandbox policies', (t) => {
-  t.todo('verify disallowed protocols are rejected');
+test('bookmark store performs CRUD operations and persists order', () => {
+  const { createBookmarkStore } = navigatorModule();
+  const settings = createSettings();
+
+  const store = createBookmarkStore({ settings });
+  const first = store.add('Example', 'https://example.com');
+  const second = store.add('Docs', 'https://docs.example.com');
+
+  assert.strictEqual(store.list().length, 2);
+  store.reorder([second.id, first.id]);
+  const reordered = store.list();
+  assert.deepStrictEqual(reordered.map((entry) => entry.id), [second.id, first.id]);
+
+  store.remove(second.id);
+  assert.deepStrictEqual(store.list().map((entry) => entry.id), [first.id]);
+
+  // Ensure persistence round trip.
+  const { createBookmarkStore: recreate } = navigatorModule();
+  const restored = recreate({ settings });
+  assert.deepStrictEqual(restored.list().map((entry) => entry.id), [first.id]);
+});
+
+test('sanitizer removes scripts, event handlers, and blocked protocols', () => {
+  const { sanitizeHtml } = sanitizerModule();
+  const dirty = `
+    <div onclick="evil()">
+      <script>alert('bad')</script>
+      <a href="javascript:alert('boom')">boom</a>
+      <img src="data:image/png;base64,abc" onload="bad()">
+    </div>
+  `;
+
+  const result = sanitizeHtml(dirty);
+  assert.ok(!result.html.includes('<script'));
+  assert.ok(!/onclick\s*=/.test(result.html));
+  assert.ok(result.blockedProtocols.includes('href:javascript'));
+  assert.ok(result.strippedAttributes.includes('onload'));
+});
+
+test('proxy validation enforces http(s) base URLs and produces proxied targets', () => {
+  const { validateProxyUrl, buildProxiedUrl } = networkProxyModule();
+
+  const valid = validateProxyUrl('http://proxy.local');
+  assert.ok(valid.valid);
+  assert.ok(valid.normalized.endsWith('/'));
+
+  const invalid = validateProxyUrl('ftp://proxy.local');
+  assert.strictEqual(invalid.valid, false);
+  assert.strictEqual(invalid.reason, 'invalid-protocol');
+
+  const proxied = buildProxiedUrl('https://proxy.local', 'https://example.com/path?q=1');
+  assert.strictEqual(
+    proxied,
+    'https://proxy.local/https%3A%2F%2Fexample.com%2Fpath%3Fq%3D1',
+  );
+});
+
+test('iframe policy blocks unsupported protocols and returns sandbox attributes', () => {
+  const { createIframePolicy } = networkIframeModule();
+  const policy = createIframePolicy({ allowScripts: true, allowSameOrigin: true });
+
+  assert.ok(policy.isUrlAllowed('https://example.com'));
+  assert.ok(!policy.isUrlAllowed('javascript:alert(1)'));
+
+  const attributes = policy.buildAttributes('https://example.com');
+  assert.match(attributes.sandbox, /allow-scripts/);
+  assert.strictEqual(attributes.referrerpolicy, 'strict-origin-when-cross-origin');
+});
+
+test('download manager drives lifecycle events and saves resources', async () => {
+  const { createDownloadManager } = downloadsModule();
+  const saved = [];
+
+  const manager = createDownloadManager({
+    fetchResource: async () => ({ data: 'payload', totalBytes: 7 }),
+    saveFile: async (record, data) => {
+      saved.push({ record, data: Buffer.from(data).toString('utf8') });
+    },
+    idGenerator: () => 'download-test',
+  });
+
+  const events = [];
+  manager.bus.on('download:completed', (event) => {
+    events.push(event.record.status);
+  });
+
+  const record = await manager.start({
+    url: 'https://example.com/file.txt',
+    filename: 'file.txt',
+  });
+
+  assert.strictEqual(record.id, 'download-test');
+  assert.strictEqual(record.status, 'completed');
+  assert.strictEqual(record.receivedBytes, 7);
+  assert.deepStrictEqual(events, ['completed']);
+  assert.deepStrictEqual(saved[0].data, 'payload');
 });


### PR DESCRIPTION
## Summary
- add the Phase 05 Navigator session controller and bookmark store backed by settings
- introduce sanitizer, iframe policy, proxy helpers, and download manager services for the browser stack
- document navigator extension points and replace the placeholder phase test coverage with concrete assertions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f65c699d348329a84c29836e322c8f