### PR TITLE
Phase 06: implement paint engine and media palette store

### DIFF
--- a/win95sim_v2/docs/creative-suite.md
+++ b/win95sim_v2/docs/creative-suite.md
@@ -1,0 +1,17 @@
+# Creative Suite Shared Assets
+
+Phase 06 introduces foundational utilities that future creative and media-focused apps can reuse without coupling to their UI layers.
+
+## Graphics utilities
+- **`@services/graphics/bitmap`** exposes helpers for working with in-memory bitmaps. It normalises colour input, bounds checks pixel writes, and provides cloning/export helpers to support undo/redo workflows.
+- The paint engine stores history snapshots as immutable bitmap clones so other tooling (e.g. thumbnail generation) can operate on snapshots without affecting the live canvas state.
+
+## Paint engine contract
+- **`@apps/creative/paint/engine`** delivers a headless drawing engine with commands for strokes, pixel placement, and region filling. The engine maintains an undo/redo stack capped by a configurable history limit and yields read-only exports that higher layers can serialise or render.
+- Strokes use a Bresenham-based rasteriser and configurable brush size, allowing additional tool implementations (airbrush, shapes) to be layered on top without modifying the core engine.
+
+## Media services
+- **`@services/media/paletteStore`** provides an async palette loader with in-flight request coalescing and an LRU cache. Media Player, Paint, and other creative apps can depend on the store to retrieve colour palettes or theme manifests without duplicating caching logic.
+- Palettes are frozen before caching so consumers cannot accidentally mutate shared data when tweaking UI themes at runtime.
+
+These shared utilities keep Phase 06 self-contained while enabling later phases (e.g., asset viewers or multimedia editors) to build upon stable contracts.

--- a/win95sim_v2/src/apps/creative/paint/engine/index.ts
+++ b/win95sim_v2/src/apps/creative/paint/engine/index.ts
@@ -1,0 +1,302 @@
+import {
+  Bitmap,
+  BitmapExport,
+  PaintColor,
+  RGBAColorTuple,
+  cloneBitmap,
+  createBitmap,
+  exportBitmap,
+  getPixel,
+  normalizeColor,
+  setPixel,
+} from '@services/graphics/bitmap';
+
+export interface PaintEngineOptions {
+  width: number;
+  height: number;
+  background?: PaintColor;
+  historyLimit?: number;
+}
+
+export interface PaintPixelCommand {
+  x: number;
+  y: number;
+  color: PaintColor;
+}
+
+export interface StrokePoint {
+  x: number;
+  y: number;
+}
+
+export interface DrawPixelsCommand {
+  type: 'drawPixels';
+  pixels: PaintPixelCommand[];
+}
+
+export interface StrokeCommand {
+  type: 'stroke';
+  points: StrokePoint[];
+  color: PaintColor;
+  size?: number;
+}
+
+export interface FillCommand {
+  type: 'fill';
+  origin: StrokePoint;
+  color: PaintColor;
+  tolerance?: number;
+}
+
+export type PaintCommand = DrawPixelsCommand | StrokeCommand | FillCommand;
+
+export interface PaintEngineSnapshot extends BitmapExport {}
+
+export interface PaintEngine {
+  apply(command: PaintCommand): void;
+  undo(): boolean;
+  redo(): boolean;
+  canUndo(): boolean;
+  canRedo(): boolean;
+  getBitmap(): Bitmap;
+  getColor(x: number, y: number): RGBAColorTuple;
+  export(): PaintEngineSnapshot;
+}
+
+const DEFAULT_HISTORY_LIMIT = 25;
+
+export function createPaintEngine(options: PaintEngineOptions): PaintEngine {
+  if (!Number.isInteger(options.width) || options.width <= 0) {
+    throw new Error('Paint engine width must be a positive integer.');
+  }
+
+  if (!Number.isInteger(options.height) || options.height <= 0) {
+    throw new Error('Paint engine height must be a positive integer.');
+  }
+
+  const historyLimit = Math.max(1, options.historyLimit ?? DEFAULT_HISTORY_LIMIT);
+  let bitmap = createBitmap(options.width, options.height, { fill: options.background });
+  const undoStack: Bitmap[] = [];
+  const redoStack: Bitmap[] = [];
+
+  function pushUndoSnapshot() {
+    undoStack.push(cloneBitmap(bitmap));
+    if (undoStack.length > historyLimit) {
+      undoStack.shift();
+    }
+  }
+
+  function applyCommand(command: PaintCommand) {
+    switch (command.type) {
+      case 'drawPixels':
+        applyDrawPixels(bitmap, command);
+        break;
+      case 'stroke':
+        applyStroke(bitmap, command);
+        break;
+      case 'fill':
+        applyFill(bitmap, command);
+        break;
+      default: {
+        const exhaustive: never = command;
+        throw new Error(`Unsupported paint command: ${exhaustive}`);
+      }
+    }
+  }
+
+  return {
+    apply(command) {
+      pushUndoSnapshot();
+      redoStack.length = 0;
+      applyCommand(command);
+    },
+    undo() {
+      if (undoStack.length === 0) {
+        return false;
+      }
+
+      redoStack.push(cloneBitmap(bitmap));
+      bitmap = undoStack.pop()!;
+      return true;
+    },
+    redo() {
+      if (redoStack.length === 0) {
+        return false;
+      }
+
+      pushUndoSnapshot();
+      bitmap = redoStack.pop()!;
+      return true;
+    },
+    canUndo() {
+      return undoStack.length > 0;
+    },
+    canRedo() {
+      return redoStack.length > 0;
+    },
+    getBitmap() {
+      return bitmap;
+    },
+    getColor(x, y) {
+      const px = clampIntoRange(clampCoordinate(x), 0, bitmap.width - 1);
+      const py = clampIntoRange(clampCoordinate(y), 0, bitmap.height - 1);
+      return getPixel(bitmap, px, py);
+    },
+    export() {
+      return exportBitmap(bitmap);
+    },
+  };
+}
+
+function applyDrawPixels(bitmap: Bitmap, command: DrawPixelsCommand): void {
+  command.pixels.forEach((pixel) => {
+    const x = clampCoordinate(pixel.x);
+    const y = clampCoordinate(pixel.y);
+    setPixel(bitmap, x, y, pixel.color);
+  });
+}
+
+function applyStroke(bitmap: Bitmap, command: StrokeCommand): void {
+  const points = command.points;
+  if (points.length === 0) {
+    return;
+  }
+
+  const color = normalizeColor(command.color);
+  const size = Math.max(1, Math.round(command.size ?? 1));
+  const stamped = new Set<string>();
+
+  function stamp(x: number, y: number) {
+    const radius = Math.max(0, Math.floor((size - 1) / 2));
+    for (let oy = -radius; oy <= radius; oy += 1) {
+      for (let ox = -radius; ox <= radius; ox += 1) {
+        const px = clampCoordinate(x + ox);
+        const py = clampCoordinate(y + oy);
+        const key = `${px},${py}`;
+        if (stamped.has(key)) {
+          continue;
+        }
+        stamped.add(key);
+        setPixel(bitmap, px, py, color);
+      }
+    }
+  }
+
+  let previous = points[0];
+  stamp(Math.round(previous.x), Math.round(previous.y));
+
+  for (let index = 1; index < points.length; index += 1) {
+    const point = points[index];
+    drawLine(previous, point, (x, y) => stamp(x, y));
+    previous = point;
+  }
+}
+
+function applyFill(bitmap: Bitmap, command: FillCommand): void {
+  const originX = clampCoordinate(command.origin.x);
+  const originY = clampCoordinate(command.origin.y);
+  if (!isWithin(bitmap, originX, originY)) {
+    return;
+  }
+
+  const target = getPixel(bitmap, originX, originY);
+  const fillColor = normalizeColor(command.color);
+  if (colorsMatch(target, fillColor)) {
+    return;
+  }
+
+  const tolerance = Math.max(0, Math.round(command.tolerance ?? 0));
+  const queue: Array<[number, number]> = [[originX, originY]];
+  const visited = new Set<string>();
+
+  while (queue.length > 0) {
+    const [x, y] = queue.shift()!;
+    const key = `${x},${y}`;
+    if (visited.has(key)) {
+      continue;
+    }
+    visited.add(key);
+
+    if (!isWithin(bitmap, x, y)) {
+      continue;
+    }
+
+    const current = getPixel(bitmap, x, y);
+    if (!colorWithinTolerance(current, target, tolerance)) {
+      continue;
+    }
+
+    setPixel(bitmap, x, y, fillColor);
+    queue.push([x + 1, y]);
+    queue.push([x - 1, y]);
+    queue.push([x, y + 1]);
+    queue.push([x, y - 1]);
+  }
+}
+
+function drawLine(from: StrokePoint, to: StrokePoint, plot: (x: number, y: number) => void): void {
+  let x0 = Math.round(from.x);
+  let y0 = Math.round(from.y);
+  const x1 = Math.round(to.x);
+  const y1 = Math.round(to.y);
+
+  const dx = Math.abs(x1 - x0);
+  const dy = Math.abs(y1 - y0);
+  const sx = x0 < x1 ? 1 : -1;
+  const sy = y0 < y1 ? 1 : -1;
+  let err = dx - dy;
+
+  while (true) {
+    plot(x0, y0);
+    if (x0 === x1 && y0 === y1) {
+      break;
+    }
+    const e2 = err * 2;
+    if (e2 > -dy) {
+      err -= dy;
+      x0 += sx;
+    }
+    if (e2 < dx) {
+      err += dx;
+      y0 += sy;
+    }
+  }
+}
+
+function colorWithinTolerance(current: RGBAColorTuple, target: RGBAColorTuple, tolerance: number): boolean {
+  if (tolerance === 0) {
+    return colorsMatch(current, target);
+  }
+
+  const dr = Math.abs(current[0] - target[0]);
+  const dg = Math.abs(current[1] - target[1]);
+  const db = Math.abs(current[2] - target[2]);
+  const da = Math.abs(current[3] - target[3]);
+  return Math.max(dr, dg, db, da) <= tolerance;
+}
+
+function colorsMatch(a: RGBAColorTuple, b: RGBAColorTuple): boolean {
+  return a[0] === b[0] && a[1] === b[1] && a[2] === b[2] && a[3] === b[3];
+}
+
+function isWithin(bitmap: Bitmap, x: number, y: number): boolean {
+  return x >= 0 && y >= 0 && x < bitmap.width && y < bitmap.height;
+}
+
+function clampCoordinate(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.round(value);
+}
+
+function clampIntoRange(value: number, min: number, max: number): number {
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+}

--- a/win95sim_v2/src/services/graphics/bitmap.ts
+++ b/win95sim_v2/src/services/graphics/bitmap.ts
@@ -1,0 +1,147 @@
+export type RGBAColorTuple = [number, number, number, number];
+
+export interface Bitmap {
+  width: number;
+  height: number;
+  data: Uint8ClampedArray;
+}
+
+export interface CreateBitmapOptions {
+  fill?: PaintColor;
+}
+
+export type PaintColor = RGBAColorTuple | RGBColorObject;
+
+export interface RGBColorObject {
+  r: number;
+  g: number;
+  b: number;
+  a?: number;
+}
+
+export interface BitmapExport {
+  width: number;
+  height: number;
+  pixels: Uint8ClampedArray;
+}
+
+const CHANNELS_PER_PIXEL = 4;
+
+export function createBitmap(width: number, height: number, options: CreateBitmapOptions = {}): Bitmap {
+  if (!Number.isInteger(width) || width <= 0) {
+    throw new Error('Bitmap width must be a positive integer.');
+  }
+
+  if (!Number.isInteger(height) || height <= 0) {
+    throw new Error('Bitmap height must be a positive integer.');
+  }
+
+  const data = new Uint8ClampedArray(width * height * CHANNELS_PER_PIXEL);
+  const fill = normalizeColor(options.fill ?? [255, 255, 255, 255]);
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      setPixelUnsafe({ width, height, data }, x, y, fill);
+    }
+  }
+
+  return { width, height, data };
+}
+
+export function cloneBitmap(source: Bitmap): Bitmap {
+  return {
+    width: source.width,
+    height: source.height,
+    data: new Uint8ClampedArray(source.data),
+  };
+}
+
+export function getPixel(bitmap: Bitmap, x: number, y: number): RGBAColorTuple {
+  if (!withinBounds(bitmap, x, y)) {
+    throw new Error(`Pixel (${x}, ${y}) is outside of the bitmap bounds.`);
+  }
+
+  const offset = getOffset(bitmap, x, y);
+  return [
+    bitmap.data[offset],
+    bitmap.data[offset + 1],
+    bitmap.data[offset + 2],
+    bitmap.data[offset + 3],
+  ];
+}
+
+export function setPixel(bitmap: Bitmap, x: number, y: number, color: PaintColor): void {
+  if (!withinBounds(bitmap, x, y)) {
+    return;
+  }
+
+  setPixelUnsafe(bitmap, x, y, normalizeColor(color));
+}
+
+export function exportBitmap(bitmap: Bitmap): BitmapExport {
+  return {
+    width: bitmap.width,
+    height: bitmap.height,
+    pixels: new Uint8ClampedArray(bitmap.data),
+  };
+}
+
+export function forEachPixel(
+  bitmap: Bitmap,
+  visitor: (x: number, y: number, color: RGBAColorTuple) => void,
+): void {
+  for (let y = 0; y < bitmap.height; y += 1) {
+    for (let x = 0; x < bitmap.width; x += 1) {
+      visitor(x, y, getPixel(bitmap, x, y));
+    }
+  }
+}
+
+export function colorsEqual(a: PaintColor, b: PaintColor): boolean {
+  const [ar, ag, ab, aa] = normalizeColor(a);
+  const [br, bg, bb, ba] = normalizeColor(b);
+  return ar === br && ag === bg && ab === bb && aa === ba;
+}
+
+export function normalizeColor(color: PaintColor): RGBAColorTuple {
+  if (Array.isArray(color)) {
+    const [r, g, b, a = 255] = color;
+    return [clamp(r), clamp(g), clamp(b), clamp(a)];
+  }
+
+  const a = color.a ?? 255;
+  return [clamp(color.r), clamp(color.g), clamp(color.b), clamp(a)];
+}
+
+function clamp(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  if (value < 0) {
+    return 0;
+  }
+
+  if (value > 255) {
+    return 255;
+  }
+
+  return Math.round(value);
+}
+
+function withinBounds(bitmap: Bitmap, x: number, y: number): boolean {
+  return x >= 0 && y >= 0 && x < bitmap.width && y < bitmap.height;
+}
+
+function getOffset(bitmap: Bitmap, x: number, y: number): number {
+  return (y * bitmap.width + x) * CHANNELS_PER_PIXEL;
+}
+
+function setPixelUnsafe(bitmap: Bitmap, x: number, y: number, color: RGBAColorTuple): void {
+  const offset = getOffset(bitmap, x, y);
+  bitmap.data[offset] = color[0];
+  bitmap.data[offset + 1] = color[1];
+  bitmap.data[offset + 2] = color[2];
+  bitmap.data[offset + 3] = color[3];
+}
+

--- a/win95sim_v2/src/services/media/paletteStore.ts
+++ b/win95sim_v2/src/services/media/paletteStore.ts
@@ -1,0 +1,112 @@
+export interface PaletteSwatch {
+  id: string;
+  color: [number, number, number];
+  label?: string;
+}
+
+export interface Palette {
+  id: string;
+  swatches: PaletteSwatch[];
+  metadata?: Record<string, unknown>;
+}
+
+export type PaletteLoader = (id: string) => Promise<Palette>;
+
+export interface PaletteStoreOptions {
+  loader: PaletteLoader;
+  cacheLimit?: number;
+}
+
+export interface PaletteStore {
+  load(id: string): Promise<Palette>;
+  getCached(id: string): Palette | undefined;
+  preload(id: string): Promise<Palette>;
+  put(palette: Palette): void;
+  clear(id?: string): void;
+  list(): string[];
+}
+
+interface InflightRequest {
+  promise: Promise<Palette>;
+  startedAt: number;
+}
+
+export function createPaletteStore(options: PaletteStoreOptions): PaletteStore {
+  const { loader } = options;
+  const cacheLimit = Math.max(1, options.cacheLimit ?? 12);
+  const cache = new Map<string, Palette>();
+  const inflight = new Map<string, InflightRequest>();
+
+  function remember(id: string, palette: Palette) {
+    if (cache.has(id)) {
+      cache.delete(id);
+    }
+    cache.set(id, freezePalette(palette));
+    while (cache.size > cacheLimit) {
+      const [oldest] = cache.keys();
+      cache.delete(oldest);
+    }
+  }
+
+  async function resolve(id: string): Promise<Palette> {
+    const existing = cache.get(id);
+    if (existing) {
+      return existing;
+    }
+
+    const pending = inflight.get(id);
+    if (pending) {
+      return pending.promise;
+    }
+
+    const promise = loader(id)
+      .then((palette) => {
+        remember(id, palette);
+        inflight.delete(id);
+        return cache.get(id)!;
+      })
+      .catch((error) => {
+        inflight.delete(id);
+        throw error;
+      });
+
+    inflight.set(id, { promise, startedAt: Date.now() });
+    return promise;
+  }
+
+  return {
+    load(id) {
+      return resolve(id);
+    },
+    preload(id) {
+      return resolve(id);
+    },
+    getCached(id) {
+      return cache.get(id);
+    },
+    put(palette) {
+      remember(palette.id, palette);
+    },
+    clear(id) {
+      if (id) {
+        cache.delete(id);
+        inflight.delete(id);
+        return;
+      }
+
+      cache.clear();
+      inflight.clear();
+    },
+    list() {
+      return Array.from(cache.keys());
+    },
+  };
+}
+
+function freezePalette(palette: Palette): Palette {
+  const frozenSwatches = palette.swatches.map((swatch) => Object.freeze({ ...swatch }));
+  return Object.freeze({
+    ...palette,
+    swatches: frozenSwatches,
+  });
+}

--- a/win95sim_v2/tests/phase06-paint.test.js
+++ b/win95sim_v2/tests/phase06-paint.test.js
@@ -1,11 +1,121 @@
 const test = require('node:test');
+const assert = require('node:assert/strict');
+const { loadModule } = require('./helpers/loadModule');
 
-// Placeholder suite for the Paint and media utilities.
+function loadPaintEngine() {
+  return loadModule('src/apps/creative/paint/engine/index.ts');
+}
 
-test('paint supports basic drawing tools', (t) => {
-  t.todo('assert bitmap buffer updates once implemented');
+function loadPaletteStore() {
+  return loadModule('src/services/media/paletteStore.ts');
+}
+
+test('paint supports basic drawing tools', () => {
+  const { createPaintEngine } = loadPaintEngine();
+  const engine = createPaintEngine({
+    width: 8,
+    height: 6,
+    background: [250, 250, 250, 255],
+    historyLimit: 8,
+  });
+
+  engine.apply({
+    type: 'stroke',
+    color: [0, 0, 0, 255],
+    points: [
+      { x: 1, y: 1 },
+      { x: 5, y: 1 },
+    ],
+  });
+
+  const drawn = Array.from({ length: 8 }, (_, x) => engine.getColor(x, 1)[0]);
+  assert.deepEqual(drawn, [250, 0, 0, 0, 0, 0, 250, 250]);
+
+  engine.apply({
+    type: 'fill',
+    origin: { x: 0, y: 0 },
+    color: [200, 220, 255, 255],
+  });
+
+  assert.deepEqual(engine.getColor(0, 0), [200, 220, 255, 255]);
+  assert.deepEqual(engine.getColor(2, 1), [0, 0, 0, 255]);
+
+  engine.apply({
+    type: 'drawPixels',
+    pixels: [
+      { x: 3, y: 3, color: [255, 0, 0, 255] },
+      { x: 4, y: 4, color: [0, 0, 255, 255] },
+    ],
+  });
+
+  const snapshot = engine.export();
+  assert.equal(snapshot.width, 8);
+  assert.equal(snapshot.height, 6);
+  assert.equal(snapshot.pixels.length, 8 * 6 * 4);
+
+  assert.equal(engine.canUndo(), true);
+  assert.equal(engine.canRedo(), false);
+
+  assert.deepEqual(engine.getColor(3, 3), [255, 0, 0, 255]);
+  assert.deepEqual(engine.getColor(4, 4), [0, 0, 255, 255]);
+
+  assert.equal(engine.undo(), true);
+  assert.deepEqual(engine.getColor(3, 3), [200, 220, 255, 255]);
+  assert.equal(engine.canRedo(), true);
+
+  assert.equal(engine.undo(), true);
+  assert.deepEqual(engine.getColor(0, 0), [250, 250, 250, 255]);
+
+  assert.equal(engine.redo(), true);
+  assert.deepEqual(engine.getColor(0, 0), [200, 220, 255, 255]);
+
+  assert.equal(engine.redo(), true);
+  assert.deepEqual(engine.getColor(3, 3), [255, 0, 0, 255]);
 });
 
-test('media service loads palette data', (t) => {
-  t.todo('mock palette fetch and verify caching');
+test('media service loads palette data', async () => {
+  const { createPaletteStore } = loadPaletteStore();
+  let loadCount = 0;
+  const store = createPaletteStore({
+    loader: async (id) => {
+      loadCount += 1;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      return {
+        id,
+        swatches: [
+          { id: 'foreground', color: [0, 0, 0] },
+          { id: 'highlight', color: [0, 120, 215] },
+        ],
+      };
+    },
+  });
+
+  const [paletteA, paletteB] = await Promise.all([
+    store.load('win95/basic'),
+    store.preload('win95/basic'),
+  ]);
+
+  assert.equal(loadCount, 1);
+  assert.strictEqual(paletteA, paletteB);
+  assert.deepEqual(store.list(), ['win95/basic']);
+  assert.strictEqual(store.getCached('win95/basic'), paletteA);
+
+  store.clear('win95/basic');
+  assert.equal(store.getCached('win95/basic'), undefined);
+
+  const paletteC = await store.load('win95/basic');
+  assert.equal(loadCount, 2);
+  assert.notStrictEqual(paletteC, paletteA);
+
+  store.put({
+    id: 'custom',
+    swatches: [
+      { id: 'primary', color: [255, 0, 0] },
+    ],
+  });
+
+  assert.deepEqual(store.list().sort(), ['custom', 'win95/basic']);
+
+  store.clear();
+  assert.deepEqual(store.list(), []);
 });


### PR DESCRIPTION
## Summary
- add a reusable bitmap helper in the graphics service for paint workflows
- implement a headless paint engine with undo/redo, stroke, fill, and pixel commands
- introduce a cached palette store and document shared creative suite utilities while covering them with tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f65c6a89c88329bd528c04ce7177c7