### PR TITLE
Add phase 07 utilities scaffolding and minesweeper engine

### DIFF
--- a/win95sim_v2/docs/utilities-extension-guide.md
+++ b/win95sim_v2/docs/utilities-extension-guide.md
@@ -1,0 +1,47 @@
+# Utilities & Games Extension Guide
+
+Phase 07 introduces a manifest-driven workflow for adding desktop utilities and games
+without editing shared shell code. Follow these steps when onboarding a new experience.
+
+## 1. Generate a scaffold
+
+Use the helper script to create a typed module stub, manifest, and Jest-style test harness:
+
+```bash
+node scripts/create-utility.js "My Utility"
+```
+
+This produces `src/apps/utilities/my-utility/` with an `index.ts` entry point and `manifest.json`
+metadata, plus a matching test file under `tests/apps/utilities/`.
+
+## 2. Register the app
+
+Utilities and games are declared in `src/apps/apps.manifest.json`. The Start menu reads this file to
+populate categories without requiring manual wiring. Manifest entries are append-only – add a new
+record instead of editing an existing one to avoid merge conflicts between parallel teams.
+
+Each record supports:
+
+- `id`: unique identifier used by the process manager and launcher shortcuts.
+- `title`: localized display name.
+- `entry`: module specifier resolved via the module registry.
+- `featureFlag`: optional flag checked by the shell before showing the shortcut.
+
+## 3. Implement the module
+
+Utilities should expose a `register()` function returning their manifest metadata. Modules may depend
+on services from `@services/*` and shared UI components from `@ui/*`, but avoid reaching into other
+apps to keep boundaries clean.
+
+For games, reuse helpers from `@services/games` for deterministic RNG and `@services/highScores`
+for session scoring. Minesweeper provides a reference implementation in
+`src/apps/games/minesweeper/` showing how to compose these services.
+
+## 4. Testing expectations
+
+- Add unit tests for new engines or service integrations beneath `tests/apps/`.
+- Seed deterministic randomness via `createSeededRandom()` so suites do not flake.
+- Use the high score service to simulate scoreboard updates where applicable.
+
+Following this flow ensures new utilities can land without conflicting with concurrent phase work
+or breaking the shell boot path.

--- a/win95sim_v2/scripts/create-utility.js
+++ b/win95sim_v2/scripts/create-utility.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+
+function usage() {
+  console.error('Usage: node scripts/create-utility.js <Utility Name>');
+}
+
+function slugify(name) {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function createFiles(rootDir, slug, title) {
+  const targetDir = path.join(rootDir, 'src', 'apps', 'utilities', slug);
+  if (fs.existsSync(targetDir)) {
+    throw new Error(`Utility folder already exists: ${slug}`);
+  }
+
+  fs.mkdirSync(targetDir, { recursive: true });
+
+  const manifestPath = path.join(targetDir, 'manifest.json');
+  const manifest = {
+    id: slug,
+    title,
+    entry: `@apps/utilities/${slug}`,
+    featureFlag: `utilities.${slug}`,
+  };
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+  const indexPath = path.join(targetDir, 'index.ts');
+  const typeName = `${title.replace(/\s+/g, '')}AppManifest`;
+  const source = `export interface ${typeName} {\n  id: string;\n}\n\nexport function register() {\n  return { id: '${slug}' };\n}\n`;
+  fs.writeFileSync(indexPath, source);
+
+  const testPath = path.join(rootDir, 'tests', 'apps', 'utilities', `${slug}.test.ts`);
+  if (!fs.existsSync(path.dirname(testPath))) {
+    fs.mkdirSync(path.dirname(testPath), { recursive: true });
+  }
+  const relativeImport = path.relative(path.dirname(testPath), indexPath).replace(/\\/g, '/');
+  const testSource = `import test from 'node:test';\nimport assert from 'node:assert/strict';\nimport { register } from '${relativeImport.replace(/\.ts$/, '')}';\n\ntest('utility ${slug} registers manifest', () => {\n  const manifest = register();\n  assert.equal(manifest.id, '${slug}');\n});\n`;
+  fs.writeFileSync(testPath, testSource);
+}
+
+function main() {
+  const rootDir = path.resolve(__dirname, '..');
+  const title = process.argv.slice(2).join(' ').trim();
+
+  if (!title) {
+    usage();
+    process.exitCode = 1;
+    return;
+  }
+
+  const slug = slugify(title);
+  if (!slug) {
+    throw new Error('Unable to derive a slug from the provided utility name');
+  }
+
+  createFiles(rootDir, slug, title);
+  console.log(`Created utility scaffold at src/apps/utilities/${slug}`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/win95sim_v2/src/apps/apps.manifest.json
+++ b/win95sim_v2/src/apps/apps.manifest.json
@@ -1,0 +1,48 @@
+{
+  "utilities": [
+    {
+      "id": "calculator",
+      "title": "Calculator",
+      "entry": "@apps/utilities/calculator",
+      "featureFlag": "utilities.calculator"
+    },
+    {
+      "id": "command-prompt",
+      "title": "Command Prompt",
+      "entry": "@apps/utilities/command-prompt",
+      "featureFlag": "utilities.commandPrompt"
+    },
+    {
+      "id": "run-dialog",
+      "title": "Run",
+      "entry": "@apps/shell/utilities/run",
+      "featureFlag": "utilities.run"
+    },
+    {
+      "id": "find-dialog",
+      "title": "Find",
+      "entry": "@apps/shell/utilities/find",
+      "featureFlag": "utilities.find"
+    },
+    {
+      "id": "shutdown-dialog",
+      "title": "Shut Down",
+      "entry": "@apps/shell/utilities/shutdown",
+      "featureFlag": "utilities.shutdown"
+    },
+    {
+      "id": "close-program",
+      "title": "Close Program",
+      "entry": "@apps/shell/utilities/close-program",
+      "featureFlag": "utilities.closeProgram"
+    }
+  ],
+  "games": [
+    {
+      "id": "minesweeper",
+      "title": "Minesweeper",
+      "entry": "@apps/games/minesweeper",
+      "featureFlag": "games.minesweeper"
+    }
+  ]
+}

--- a/win95sim_v2/src/apps/games/minesweeper/engine.ts
+++ b/win95sim_v2/src/apps/games/minesweeper/engine.ts
@@ -1,0 +1,303 @@
+import { createSeededRandom } from '@services/games';
+import type { MinesweeperCellState, MinesweeperConfig, MinesweeperDifficulty, MinesweeperEngine, MinesweeperState } from './types';
+
+const DEFAULT_DIFFICULTY: MinesweeperDifficulty = 'custom';
+
+interface InternalState {
+  config: MinesweeperConfig;
+  board: MinesweeperCellState[][];
+  status: MinesweeperState['status'];
+  revealed: number;
+  flags: number;
+  firstMove: boolean;
+}
+
+function createEmptyBoard(width: number, height: number): MinesweeperCellState[][] {
+  const board: MinesweeperCellState[][] = [];
+  for (let y = 0; y < height; y += 1) {
+    const row: MinesweeperCellState[] = [];
+    for (let x = 0; x < width; x += 1) {
+      row.push({
+        x,
+        y,
+        hasMine: false,
+        isRevealed: false,
+        isFlagged: false,
+        adjacentMines: 0,
+      });
+    }
+    board.push(row);
+  }
+  return board;
+}
+
+function forEachNeighbour(width: number, height: number, x: number, y: number, visit: (nx: number, ny: number) => void) {
+  for (let offsetY = -1; offsetY <= 1; offsetY += 1) {
+    for (let offsetX = -1; offsetX <= 1; offsetX += 1) {
+      if (offsetX === 0 && offsetY === 0) {
+        continue;
+      }
+      const nx = x + offsetX;
+      const ny = y + offsetY;
+      if (nx >= 0 && ny >= 0 && nx < width && ny < height) {
+        visit(nx, ny);
+      }
+    }
+  }
+}
+
+function applyMineCounts(board: MinesweeperCellState[][]) {
+  const height = board.length;
+  const width = board[0]?.length ?? 0;
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const cell = board[y][x];
+      if (cell.hasMine) {
+        cell.adjacentMines = -1;
+        continue;
+      }
+      let count = 0;
+      forEachNeighbour(width, height, x, y, (nx, ny) => {
+        if (board[ny][nx].hasMine) {
+          count += 1;
+        }
+      });
+      cell.adjacentMines = count;
+    }
+  }
+}
+
+function serializeIndex(width: number, x: number, y: number) {
+  return y * width + x;
+}
+
+function deserializeIndex(width: number, index: number) {
+  const x = index % width;
+  const y = (index - x) / width;
+  return { x, y };
+}
+
+function placeMines(board: MinesweeperCellState[][], mines: number, seed?: string) {
+  const height = board.length;
+  const width = board[0]?.length ?? 0;
+  const rng = createSeededRandom(seed);
+  const available = new Array(width * height).fill(0).map((_, index) => index);
+  rng.shuffle(available);
+  const mineSlots = available.slice(0, mines);
+
+  for (const slot of mineSlots) {
+    const { x, y } = deserializeIndex(width, slot);
+    board[y][x].hasMine = true;
+  }
+
+  applyMineCounts(board);
+}
+
+function cloneBoard(board: MinesweeperCellState[][]): MinesweeperCellState[][] {
+  return board.map((row) => row.map((cell) => ({ ...cell })));
+}
+
+function ensureFirstClickSafe(state: InternalState, x: number, y: number) {
+  const { config, board } = state;
+  const target = board[y]?.[x];
+  if (!target || !target.hasMine) {
+    return;
+  }
+
+  const width = config.width;
+  const height = config.height;
+  const rng = createSeededRandom(`${config.seed ?? ''}:safety:${x},${y}`);
+  const candidates: number[] = [];
+  for (let index = 0; index < width * height; index += 1) {
+    const { x: cx, y: cy } = deserializeIndex(width, index);
+    if (!board[cy][cx].hasMine && !(cx === x && cy === y)) {
+      candidates.push(index);
+    }
+  }
+
+  if (!candidates.length) {
+    return;
+  }
+
+  const replacementIndex = rng.shuffle(candidates.slice())[0];
+  const { x: nx, y: ny } = deserializeIndex(width, replacementIndex);
+
+  board[y][x].hasMine = false;
+  board[ny][nx].hasMine = true;
+
+  applyMineCounts(board);
+}
+
+function floodReveal(state: InternalState, x: number, y: number) {
+  const { board, config } = state;
+  const stack: Array<{ x: number; y: number }> = [{ x, y }];
+  const seen = new Set<number>();
+  const width = config.width;
+
+  while (stack.length) {
+    const current = stack.pop()!;
+    const cell = board[current.y]?.[current.x];
+    if (!cell || cell.isRevealed || cell.isFlagged) {
+      continue;
+    }
+    const index = serializeIndex(width, current.x, current.y);
+    if (seen.has(index)) {
+      continue;
+    }
+    seen.add(index);
+    cell.isRevealed = true;
+    state.revealed += 1;
+    if (cell.adjacentMines === 0) {
+      forEachNeighbour(config.width, config.height, current.x, current.y, (nx, ny) => {
+        stack.push({ x: nx, y: ny });
+      });
+    }
+  }
+}
+
+function evaluateStatus(state: InternalState) {
+  if (state.status === 'lost') {
+    return;
+  }
+
+  const totalCells = state.config.width * state.config.height;
+  const targetRevealed = totalCells - state.config.mines;
+  if (state.revealed >= targetRevealed) {
+    state.status = 'won';
+  }
+}
+
+function validateConfig(config: MinesweeperConfig) {
+  if (config.width <= 0 || config.height <= 0) {
+    throw new Error('Board dimensions must be greater than zero');
+  }
+  if (!Number.isInteger(config.width) || !Number.isInteger(config.height)) {
+    throw new Error('Board dimensions must be integers');
+  }
+  if (!Number.isInteger(config.mines) || config.mines <= 0) {
+    throw new Error('Mine count must be a positive integer');
+  }
+  if (config.mines >= config.width * config.height) {
+    throw new Error('Mine count must be less than the total number of cells');
+  }
+}
+
+function deriveDifficulty(config: MinesweeperConfig): MinesweeperDifficulty {
+  if (config.difficulty) {
+    return config.difficulty;
+  }
+  if (config.width === 9 && config.height === 9 && config.mines === 10) {
+    return 'beginner';
+  }
+  if (config.width === 16 && config.height === 16 && config.mines === 40) {
+    return 'intermediate';
+  }
+  if (config.width === 30 && config.height === 16 && config.mines === 99) {
+    return 'expert';
+  }
+  return DEFAULT_DIFFICULTY;
+}
+
+function createInitialState(config: MinesweeperConfig): InternalState {
+  validateConfig(config);
+  const board = createEmptyBoard(config.width, config.height);
+  placeMines(board, config.mines, config.seed);
+  return {
+    config,
+    board,
+    status: 'ready',
+    revealed: 0,
+    flags: 0,
+    firstMove: true,
+  };
+}
+
+function toPublicState(state: InternalState): MinesweeperState {
+  return {
+    board: cloneBoard(state.board),
+    status: state.status,
+    revealed: state.revealed,
+    flags: state.flags,
+    mines: state.config.mines,
+    width: state.config.width,
+    height: state.config.height,
+    difficulty: deriveDifficulty(state.config),
+  };
+}
+
+export function createMinesweeperEngine(config: MinesweeperConfig): MinesweeperEngine {
+  const internal: InternalState = createInitialState({
+    ...config,
+    firstClickSafe: config.firstClickSafe ?? true,
+  });
+
+  function revealCell(x: number, y: number) {
+    if (internal.status === 'lost' || internal.status === 'won') {
+      return;
+    }
+
+    const cell = internal.board[y]?.[x];
+    if (!cell || cell.isFlagged || cell.isRevealed) {
+      return;
+    }
+
+    if (internal.firstMove && internal.config.firstClickSafe) {
+      ensureFirstClickSafe(internal, x, y);
+    }
+
+    internal.firstMove = false;
+
+    if (cell.hasMine) {
+      cell.isRevealed = true;
+      internal.status = 'lost';
+      internal.revealed += 1;
+      return;
+    }
+
+    floodReveal(internal, x, y);
+    if (internal.status === 'ready') {
+      internal.status = 'in-progress';
+    }
+    evaluateStatus(internal);
+  }
+
+  function toggleFlag(x: number, y: number) {
+    if (internal.status === 'lost' || internal.status === 'won') {
+      return;
+    }
+    const cell = internal.board[y]?.[x];
+    if (!cell || cell.isRevealed) {
+      return;
+    }
+    cell.isFlagged = !cell.isFlagged;
+    internal.flags += cell.isFlagged ? 1 : -1;
+  }
+
+  return {
+    getState() {
+      return toPublicState(internal);
+    },
+    reveal(x: number, y: number) {
+      revealCell(x, y);
+      return toPublicState(internal);
+    },
+    toggleFlag(x: number, y: number) {
+      toggleFlag(x, y);
+      return toPublicState(internal);
+    },
+    reset(seed?: string) {
+      const nextConfig: MinesweeperConfig = {
+        ...internal.config,
+        seed: seed ?? internal.config.seed,
+      };
+      const nextState = createInitialState(nextConfig);
+      internal.board = nextState.board;
+      internal.status = nextState.status;
+      internal.revealed = nextState.revealed;
+      internal.flags = nextState.flags;
+      internal.firstMove = nextState.firstMove;
+      internal.config = nextState.config;
+      return toPublicState(internal);
+    },
+  };
+}

--- a/win95sim_v2/src/apps/games/minesweeper/index.ts
+++ b/win95sim_v2/src/apps/games/minesweeper/index.ts
@@ -1,0 +1,8 @@
+export { createMinesweeperEngine } from './engine';
+export type {
+  MinesweeperEngine,
+  MinesweeperState,
+  MinesweeperCellState,
+  MinesweeperConfig,
+  MinesweeperDifficulty,
+} from './types';

--- a/win95sim_v2/src/apps/games/minesweeper/types.ts
+++ b/win95sim_v2/src/apps/games/minesweeper/types.ts
@@ -1,0 +1,37 @@
+export type MinesweeperDifficulty = 'beginner' | 'intermediate' | 'expert' | 'custom';
+
+export interface MinesweeperConfig {
+  width: number;
+  height: number;
+  mines: number;
+  seed?: string;
+  difficulty?: MinesweeperDifficulty;
+  firstClickSafe?: boolean;
+}
+
+export interface MinesweeperCellState {
+  x: number;
+  y: number;
+  hasMine: boolean;
+  isRevealed: boolean;
+  isFlagged: boolean;
+  adjacentMines: number;
+}
+
+export interface MinesweeperState {
+  board: MinesweeperCellState[][];
+  status: 'ready' | 'in-progress' | 'won' | 'lost';
+  revealed: number;
+  flags: number;
+  mines: number;
+  width: number;
+  height: number;
+  difficulty: MinesweeperDifficulty;
+}
+
+export interface MinesweeperEngine {
+  getState(): MinesweeperState;
+  reveal(x: number, y: number): MinesweeperState;
+  toggleFlag(x: number, y: number): MinesweeperState;
+  reset(seed?: string): MinesweeperState;
+}

--- a/win95sim_v2/src/services/games/index.ts
+++ b/win95sim_v2/src/services/games/index.ts
@@ -1,0 +1,2 @@
+export { createSeededRandom } from './seededRandom';
+export type { SeededRandom } from './seededRandom';

--- a/win95sim_v2/src/services/games/seededRandom.ts
+++ b/win95sim_v2/src/services/games/seededRandom.ts
@@ -1,0 +1,67 @@
+export interface SeededRandom {
+  /**
+   * Returns a floating point number in the range [0, 1).
+   */
+  next(): number;
+  /**
+   * Returns an integer between the provided bounds (inclusive of min, exclusive of max).
+   */
+  nextInt(min: number, max: number): number;
+  /**
+   * Shuffles the provided array in-place and returns it.
+   */
+  shuffle<T>(items: T[]): T[];
+}
+
+function normalizeSeed(seed: string | number | undefined): number {
+  if (typeof seed === 'number' && Number.isFinite(seed)) {
+    return seed >>> 0;
+  }
+
+  const text = String(seed ?? 'win95sim');
+  let hash = 2166136261;
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return hash >>> 0;
+}
+
+function createMulberry32(state: number) {
+  let current = state || 1;
+  return function next() {
+    current += 0x6d2b79f5;
+    let t = current;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function createSeededRandom(seed?: string | number): SeededRandom {
+  const generator = createMulberry32(normalizeSeed(seed));
+
+  return {
+    next() {
+      return generator();
+    },
+    nextInt(min: number, max: number) {
+      if (!Number.isFinite(min) || !Number.isFinite(max)) {
+        throw new Error('Bounds must be finite numbers');
+      }
+      if (max <= min) {
+        throw new Error('Max must be greater than min');
+      }
+      const span = max - min;
+      return Math.floor(generator() * span + min);
+    },
+    shuffle<T>(items: T[]) {
+      for (let index = items.length - 1; index > 0; index -= 1) {
+        const swapWith = this.nextInt(0, index + 1);
+        [items[index], items[swapWith]] = [items[swapWith], items[index]];
+      }
+      return items;
+    },
+  };
+}

--- a/win95sim_v2/src/services/highScores/index.ts
+++ b/win95sim_v2/src/services/highScores/index.ts
@@ -1,0 +1,121 @@
+export interface HighScoreEntry {
+  player: string;
+  value: number;
+  unit: string;
+  achievedAt: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RecordScoreOptions {
+  table: string;
+  player: string;
+  value: number;
+  unit: string;
+  lowerIsBetter?: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface HighScoreService {
+  recordScore(options: RecordScoreOptions): { accepted: boolean; position: number | null; entries: HighScoreEntry[] };
+  getScores(table: string): HighScoreEntry[];
+  reset(table?: string): void;
+}
+
+interface HighScoreServiceOptions {
+  now?: () => number;
+  limit?: number;
+}
+
+function cloneEntry(entry: HighScoreEntry): HighScoreEntry {
+  return {
+    player: entry.player,
+    value: entry.value,
+    unit: entry.unit,
+    achievedAt: entry.achievedAt,
+    metadata: entry.metadata ? { ...entry.metadata } : undefined,
+  };
+}
+
+export function createHighScoreService(options: HighScoreServiceOptions = {}): HighScoreService {
+  const now = options.now ?? (() => Date.now());
+  const limit = options.limit ?? 5;
+  const tables = new Map<string, HighScoreEntry[]>();
+
+  function sortEntries(entries: HighScoreEntry[], lowerIsBetter: boolean) {
+    entries.sort((a, b) => {
+      if (a.value === b.value) {
+        return a.achievedAt - b.achievedAt;
+      }
+      return lowerIsBetter ? a.value - b.value : b.value - a.value;
+    });
+  }
+
+  function ensureTable(id: string) {
+    if (!tables.has(id)) {
+      tables.set(id, []);
+    }
+    return tables.get(id)!;
+  }
+
+  return {
+    recordScore({ table, player, value, unit, lowerIsBetter = true, metadata }) {
+      if (!table) {
+        throw new Error('High score table id is required');
+      }
+      if (!player) {
+        throw new Error('Player name is required');
+      }
+      if (!Number.isFinite(value)) {
+        throw new Error('Score value must be a finite number');
+      }
+
+      const entries = ensureTable(table);
+      const existingIndex = entries.findIndex((entry) => entry.player === player);
+      const entry: HighScoreEntry = {
+        player,
+        value,
+        unit,
+        achievedAt: now(),
+        metadata: metadata ? { ...metadata } : undefined,
+      };
+
+      if (existingIndex >= 0) {
+        const current = entries[existingIndex];
+        const isBetter = lowerIsBetter ? value < current.value : value > current.value;
+        if (!isBetter) {
+          return { accepted: false, position: null, entries: entries.map(cloneEntry) };
+        }
+        entries.splice(existingIndex, 1, entry);
+      } else {
+        entries.push(entry);
+      }
+
+      sortEntries(entries, lowerIsBetter);
+
+      if (entries.length > limit) {
+        entries.length = limit;
+      }
+
+      const position = entries.findIndex((item) => item === entry);
+      return {
+        accepted: position !== -1,
+        position: position === -1 ? null : position,
+        entries: entries.map(cloneEntry),
+      };
+    },
+    getScores(table: string) {
+      const entries = tables.get(table);
+      if (!entries) {
+        return [];
+      }
+      return entries.map(cloneEntry);
+    },
+    reset(table?: string) {
+      if (typeof table === 'string') {
+        tables.delete(table);
+      } else {
+        tables.clear();
+      }
+    },
+  };
+}

--- a/win95sim_v2/tests/phase07-games.test.js
+++ b/win95sim_v2/tests/phase07-games.test.js
@@ -1,11 +1,80 @@
 const test = require('node:test');
+const assert = require('node:assert/strict');
+const { loadModule } = require('./helpers/loadModule');
 
-// Placeholder suite for games and utility applications.
+function serializeBoard(board) {
+  return board.map((row) => row.map((cell) => (cell.hasMine ? 'M' : String(cell.adjacentMines))).join('')).join('\n');
+}
 
-test('minesweeper enforces deterministic random seeds', (t) => {
-  t.todo('expose seedable RNG in utilities package');
+function countMines(board) {
+  return board.reduce((sum, row) => sum + row.filter((cell) => cell.hasMine).length, 0);
+}
+
+test('minesweeper uses deterministic seeds and first click safety', () => {
+  const { createMinesweeperEngine } = loadModule('src/apps/games/minesweeper/engine.ts');
+
+  const config = { width: 9, height: 9, mines: 10, seed: 'phase-07' };
+  const engineA = createMinesweeperEngine(config);
+  const engineB = createMinesweeperEngine(config);
+
+  const initialA = engineA.getState();
+  const initialB = engineB.getState();
+  assert.equal(initialA.status, 'ready');
+  assert.equal(initialB.status, 'ready');
+  assert.deepEqual(serializeBoard(initialA.board), serializeBoard(initialB.board));
+
+  const afterRevealA = engineA.reveal(0, 0);
+  const afterRevealB = engineB.reveal(0, 0);
+
+  assert.equal(afterRevealA.board[0][0].hasMine, false);
+  assert.equal(afterRevealA.board[0][0].isRevealed, true);
+  assert.equal(afterRevealB.board[0][0].hasMine, false);
+  assert.equal(afterRevealB.board[0][0].isRevealed, true);
+
+  assert.deepEqual(serializeBoard(afterRevealA.board), serializeBoard(afterRevealB.board));
+  assert.equal(countMines(afterRevealA.board), config.mines);
+  assert.equal(afterRevealA.mines, config.mines);
+  assert.match(afterRevealA.status, /in-progress|won/);
 });
 
-test('solitaire tracks score and undo history', (t) => {
-  t.todo('implement scoring rules when cards engine is ready');
+test('high score service ranks lowest values first and deduplicates players', () => {
+  const { createHighScoreService } = loadModule('src/services/highScores/index.ts');
+
+  let tick = 0;
+  const service = createHighScoreService({ now: () => ++tick, limit: 3 });
+
+  service.recordScore({ table: 'minesweeper:beginner', player: 'Alice', value: 45, unit: 'seconds' });
+  service.recordScore({ table: 'minesweeper:beginner', player: 'Bob', value: 38, unit: 'seconds' });
+  service.recordScore({ table: 'minesweeper:beginner', player: 'Carol', value: 39, unit: 'seconds' });
+
+  let scores = service.getScores('minesweeper:beginner');
+  assert.deepEqual(scores.map((entry) => entry.player), ['Bob', 'Carol', 'Alice']);
+
+  const rejected = service.recordScore({ table: 'minesweeper:beginner', player: 'Bob', value: 50, unit: 'seconds' });
+  assert.equal(rejected.accepted, false);
+  assert.equal(rejected.position, null);
+
+  const updated = service.recordScore({ table: 'minesweeper:beginner', player: 'Alice', value: 30, unit: 'seconds' });
+  assert.equal(updated.accepted, true);
+  assert.equal(updated.position, 0);
+
+  scores = service.getScores('minesweeper:beginner');
+  assert.deepEqual(scores.map((entry) => entry.player), ['Alice', 'Bob', 'Carol']);
+  assert.ok(scores.every((entry) => typeof entry.achievedAt === 'number'));
+});
+
+test('seeded random generates repeatable sequences', () => {
+  const { createSeededRandom } = loadModule('src/services/games/seededRandom.ts');
+
+  const rngA = createSeededRandom('win95');
+  const rngB = createSeededRandom('win95');
+  const valuesA = Array.from({ length: 5 }, () => rngA.next());
+  const valuesB = Array.from({ length: 5 }, () => rngB.next());
+
+  assert.deepEqual(valuesA, valuesB);
+  assert.ok(valuesA.every((value) => value >= 0 && value < 1));
+
+  const intsA = Array.from({ length: 5 }, (_, index) => rngA.nextInt(0, index + 5));
+  const intsB = Array.from({ length: 5 }, (_, index) => rngB.nextInt(0, index + 5));
+  assert.deepEqual(intsA, intsB);
 });


### PR DESCRIPTION
## Summary
- add deterministic RNG and shared high score services for utilities and games
- implement a seedable minesweeper engine and manifest entries for desktop utilities
- document the extension workflow and provide a generator script for new utilities

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f65c6b946883299f404c9edf4503ef