### PR TITLE
Add control panel applets and print service queue

### DIFF
--- a/win95sim_v2/docs/control-panel-extension.md
+++ b/win95sim_v2/docs/control-panel-extension.md
@@ -1,0 +1,32 @@
+# Control Panel Extension Guide
+
+The Control Panel hub is manifest driven so individual teams can add applets
+without editing shared hub source. Follow these steps when introducing a new
+applet:
+
+1. **Create the module**
+   - Place implementation files under `src/apps/system/control-panel/applets/<id>/`.
+   - Export a `createApplet(context, manifest)` function that returns a
+     `ControlPanelApplet` instance. Reuse the shared context for access to
+     `@services/display`, `@services/settings`, and `@services/print`.
+2. **Register in the manifest**
+   - Append an entry to `src/apps/system/control-panel/control-panel.manifest.json`
+     with a unique `id`, title, category, keywords, and module path.
+   - IDs are slug based (e.g., `network`) and must remain stable for saved state.
+3. **Rely on the registry**
+   - The Control Panel boot sequence calls
+     `registerControlPanelApplets(registry, context)` which loads every manifest
+     entry via dynamic imports and registers it under `apps/control-panel/<id>`.
+   - Avoid manual registry calls inside the applet to prevent duplicate
+     instances.
+4. **Expose deterministic surfaces**
+   - Applet `open()` methods should return pure state containers or controllers
+     that can be unit tested without DOM dependencies.
+   - Persist user changes through the shared services instead of local storage.
+5. **Document settings contracts**
+   - If the applet introduces new settings keys or events, document them in
+     `docs/module-apis-v2.md` so other teams understand the surface area.
+
+The automated unit tests assert manifest integrity, so malformed entries will be
+caught during CI. Use `npm test` before submitting changes to confirm the
+manifest compiles and applets register correctly.

--- a/win95sim_v2/docs/module-apis-v2.md
+++ b/win95sim_v2/docs/module-apis-v2.md
@@ -137,6 +137,60 @@ interface LocalizationService {
 }
 ```
 
+### `services/print`
+Queues jobs for installed printers and writes output to the virtual spooler.
+```ts
+type PrinterDriver = 'generic-text' | 'virtual-pdf';
+
+interface PrinterDefinition {
+  id: string;
+  name: string;
+  driver: PrinterDriver;
+  description?: string;
+  isDefault?: boolean;
+  capabilities?: string[];
+}
+
+type PrintJobStatus = 'queued' | 'printing' | 'paused' | 'completed' | 'cancelled' | 'error';
+
+interface PrintJobRequest {
+  printerId: string;
+  documentName: string;
+  content: string;
+  copies?: number;
+  contentType?: string;
+}
+
+interface PrintJob extends PrintJobRequest {
+  id: string;
+  status: PrintJobStatus;
+  outputPath?: string;
+  error?: string;
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+}
+
+interface PrintService {
+  listPrinters(): PrinterDefinition[];
+  getPrinter(id: string): PrinterDefinition | undefined;
+  installPrinter(printer: PrinterDefinition): PrinterDefinition;
+  removePrinter(id: string): PrinterDefinition | undefined;
+  submitJob(request: PrintJobRequest): PrintJob;
+  getJob(id: string): PrintJob | undefined;
+  listJobs(printerId?: string): PrintJob[];
+  pauseJob(id: string): PrintJob | undefined;
+  resumeJob(id: string): PrintJob | undefined;
+  cancelJob(id: string): PrintJob | undefined;
+  processNextJob(): PrintJob | undefined;
+  processAllJobs(): PrintJob[];
+  bus: EventBus;
+}
+```
+`processNextJob()` and `processAllJobs()` are primarily used by automated tests
+to step through the queue deterministically. Runtime callers typically rely on
+the auto-processing behaviour provided by the default service implementation.
+
 ## UI primitives
 ### CSS tokens (`ui/tokens.css`)
 ```css
@@ -185,6 +239,33 @@ Apps are declared via manifests under `apps/<name>/module.json`:
 }
 ```
 The build pipeline validates manifests for conflicting IDs and missing permissions during Phase 01.
+
+### `apps/control-panel`
+Loads applets from `src/apps/system/control-panel/control-panel.manifest.json`
+and registers each module as `apps/control-panel/<id>`.
+```ts
+interface ControlPanelContext {
+  display: DisplayService;
+  settings: SettingsService;
+  print: PrintService;
+}
+
+interface ControlPanelApplet {
+  id: string;
+  title: string;
+  category: string;
+  keywords: string[];
+  manifest: ControlPanelManifestEntry;
+  open(): ControlPanelAppletSession;
+}
+
+interface ControlPanelAppletSession {
+  tabs: string[];
+  dispose(): void;
+}
+```
+Applets implement `createApplet(context, manifest)` and expose pure controller
+APIs so downstream features can unit test behaviour without rendering UI.
 
 ## Telemetry & diagnostics
 Phase 10 introduces optional telemetry via `services/diagnostics`. Until then, the interface is stubbed:

--- a/win95sim_v2/src/apps/system/control-panel/applets/dateTime/index.ts
+++ b/win95sim_v2/src/apps/system/control-panel/applets/dateTime/index.ts
@@ -1,0 +1,50 @@
+import type { ControlPanelApplet, ControlPanelContext, DateTimeAppletSession } from '../../types';
+import type { ControlPanelManifestEntry } from '../../manifest';
+
+const OFFSET_KEY = 'time.offsetMinutes';
+
+function clampOffset(value: number) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(-720, Math.min(840, Math.round(value)));
+}
+
+export function createApplet(
+  context: ControlPanelContext,
+  manifest: ControlPanelManifestEntry,
+): ControlPanelApplet<DateTimeAppletSession> {
+  const { settings } = context;
+
+  return {
+    id: `control-panel/${manifest.id}`,
+    title: manifest.title,
+    description: manifest.description,
+    category: manifest.category,
+    keywords: [...manifest.keywords],
+    manifest,
+    open(): DateTimeAppletSession {
+      const initial = clampOffset((settings.get(OFFSET_KEY, 0) as number) ?? 0);
+      let pending = initial;
+
+      return {
+        tabs: ['Date & Time', 'Time Zone'],
+        getOffsetMinutes() {
+          return pending;
+        },
+        setOffsetMinutes(minutes: number) {
+          pending = clampOffset(minutes);
+        },
+        apply() {
+          settings.set(OFFSET_KEY, pending);
+        },
+        reset() {
+          pending = clampOffset((settings.get(OFFSET_KEY, 0) as number) ?? 0);
+        },
+        dispose() {
+          pending = initial;
+        },
+      };
+    },
+  };
+}

--- a/win95sim_v2/src/apps/system/control-panel/applets/display/index.ts
+++ b/win95sim_v2/src/apps/system/control-panel/applets/display/index.ts
@@ -1,0 +1,71 @@
+import type { DisplayState, ScalingMode } from '@services/display';
+import type { ControlPanelApplet, ControlPanelContext, DisplayAppletSession } from '../../types';
+import type { ControlPanelManifestEntry } from '../../manifest';
+
+function cloneState(state: DisplayState): DisplayState {
+  return { ...state };
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function createApplet(
+  context: ControlPanelContext,
+  manifest: ControlPanelManifestEntry,
+): ControlPanelApplet<DisplayAppletSession> {
+  const { display } = context;
+
+  return {
+    id: `control-panel/${manifest.id}`,
+    title: manifest.title,
+    description: manifest.description,
+    category: manifest.category,
+    keywords: [...manifest.keywords],
+    manifest,
+    open(): DisplayAppletSession {
+      const base = display.getState();
+      let applied = cloneState(base);
+      let pending = cloneState(base);
+
+      function updateResolution(width: number, height: number) {
+        width = clamp(width, 320, 2048);
+        height = clamp(height, 200, 1536);
+        pending = { ...pending, width, height };
+      }
+
+      return {
+        tabs: ['Background', 'Screen Saver', 'Appearance', 'Settings'],
+        state: {
+          get applied() {
+            return cloneState(applied);
+          },
+          get pending() {
+            return cloneState(pending);
+          },
+        },
+        previewResolution(width: number, height: number) {
+          updateResolution(width, height);
+        },
+        setScalingMode(mode: ScalingMode) {
+          pending = { ...pending, scalingMode: mode };
+        },
+        toggleIntegerScale(enabled: boolean) {
+          pending = { ...pending, integerScale: !!enabled };
+        },
+        apply() {
+          applied = cloneState(pending);
+          display.setResolution(applied.width, applied.height);
+          display.setScalingMode(applied.scalingMode);
+          display.toggleIntegerScale(applied.integerScale);
+        },
+        cancel() {
+          pending = cloneState(applied);
+        },
+        dispose() {
+          pending = cloneState(applied);
+        },
+      };
+    },
+  };
+}

--- a/win95sim_v2/src/apps/system/control-panel/applets/input/index.ts
+++ b/win95sim_v2/src/apps/system/control-panel/applets/input/index.ts
@@ -1,0 +1,62 @@
+import type { ControlPanelApplet, ControlPanelContext, InputAppletSession } from '../../types';
+import type { ControlPanelManifestEntry } from '../../manifest';
+
+const RATE_KEY = 'input.repeatRate';
+const DELAY_KEY = 'input.repeatDelay';
+
+function clamp(value: number, min: number, max: number) {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.max(min, Math.min(max, Math.round(value)));
+}
+
+export function createApplet(
+  context: ControlPanelContext,
+  manifest: ControlPanelManifestEntry,
+): ControlPanelApplet<InputAppletSession> {
+  const { settings } = context;
+
+  return {
+    id: `control-panel/${manifest.id}`,
+    title: manifest.title,
+    description: manifest.description,
+    category: manifest.category,
+    keywords: [...manifest.keywords],
+    manifest,
+    open(): InputAppletSession {
+      const initialRate = clamp((settings.get(RATE_KEY, 31) as number) ?? 31, 1, 31);
+      const initialDelay = clamp((settings.get(DELAY_KEY, 2) as number) ?? 2, 1, 4);
+      let rate = initialRate;
+      let delay = initialDelay;
+
+      return {
+        tabs: ['Speed'],
+        getRepeatRate() {
+          return rate;
+        },
+        setRepeatRate(next: number) {
+          rate = clamp(next, 1, 31);
+        },
+        getDelay() {
+          return delay;
+        },
+        setDelay(next: number) {
+          delay = clamp(next, 1, 4);
+        },
+        apply() {
+          settings.set(RATE_KEY, rate);
+          settings.set(DELAY_KEY, delay);
+        },
+        reset() {
+          rate = clamp((settings.get(RATE_KEY, initialRate) as number) ?? initialRate, 1, 31);
+          delay = clamp((settings.get(DELAY_KEY, initialDelay) as number) ?? initialDelay, 1, 4);
+        },
+        dispose() {
+          rate = initialRate;
+          delay = initialDelay;
+        },
+      };
+    },
+  };
+}

--- a/win95sim_v2/src/apps/system/control-panel/applets/mouse/index.ts
+++ b/win95sim_v2/src/apps/system/control-panel/applets/mouse/index.ts
@@ -1,0 +1,62 @@
+import type { ControlPanelApplet, ControlPanelContext, MouseAppletSession } from '../../types';
+import type { ControlPanelManifestEntry } from '../../manifest';
+
+const SPEED_KEY = 'mouse.pointerSpeed';
+const DOUBLE_CLICK_KEY = 'mouse.doubleClickSpeed';
+
+function clamp(value: number, min: number, max: number) {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.max(min, Math.min(max, Math.round(value)));
+}
+
+export function createApplet(
+  context: ControlPanelContext,
+  manifest: ControlPanelManifestEntry,
+): ControlPanelApplet<MouseAppletSession> {
+  const { settings } = context;
+
+  return {
+    id: `control-panel/${manifest.id}`,
+    title: manifest.title,
+    description: manifest.description,
+    category: manifest.category,
+    keywords: [...manifest.keywords],
+    manifest,
+    open(): MouseAppletSession {
+      const initialSpeed = clamp((settings.get(SPEED_KEY, 10) as number) ?? 10, 1, 20);
+      const initialDoubleClick = clamp((settings.get(DOUBLE_CLICK_KEY, 500) as number) ?? 500, 200, 1000);
+      let speed = initialSpeed;
+      let doubleClick = initialDoubleClick;
+
+      return {
+        tabs: ['Buttons', 'Pointers', 'Motion', 'Wheel'],
+        getPointerSpeed() {
+          return speed;
+        },
+        setPointerSpeed(next: number) {
+          speed = clamp(next, 1, 20);
+        },
+        getDoubleClickSpeed() {
+          return doubleClick;
+        },
+        setDoubleClickSpeed(next: number) {
+          doubleClick = clamp(next, 200, 1000);
+        },
+        apply() {
+          settings.set(SPEED_KEY, speed);
+          settings.set(DOUBLE_CLICK_KEY, doubleClick);
+        },
+        reset() {
+          speed = clamp((settings.get(SPEED_KEY, initialSpeed) as number) ?? initialSpeed, 1, 20);
+          doubleClick = clamp((settings.get(DOUBLE_CLICK_KEY, initialDoubleClick) as number) ?? initialDoubleClick, 200, 1000);
+        },
+        dispose() {
+          speed = initialSpeed;
+          doubleClick = initialDoubleClick;
+        },
+      };
+    },
+  };
+}

--- a/win95sim_v2/src/apps/system/control-panel/applets/printers/index.ts
+++ b/win95sim_v2/src/apps/system/control-panel/applets/printers/index.ts
@@ -1,0 +1,66 @@
+import type { ControlPanelApplet, ControlPanelContext, PrintersAppletSession } from '../../types';
+import type { ControlPanelManifestEntry } from '../../manifest';
+import type { PrinterDefinition } from '@services/print';
+
+function normalizePrinter(definition: PrinterDefinition): PrinterDefinition {
+  return {
+    ...definition,
+    id: definition.id.trim(),
+    name: definition.name.trim(),
+    driver: definition.driver,
+    description: definition.description?.trim(),
+    capabilities: definition.capabilities ? [...definition.capabilities] : undefined,
+  };
+}
+
+export function createApplet(
+  context: ControlPanelContext,
+  manifest: ControlPanelManifestEntry,
+): ControlPanelApplet<PrintersAppletSession> {
+  const { print } = context;
+
+  return {
+    id: `control-panel/${manifest.id}`,
+    title: manifest.title,
+    description: manifest.description,
+    category: manifest.category,
+    keywords: [...manifest.keywords],
+    manifest,
+    open(): PrintersAppletSession {
+      return {
+        tabs: ['Printers', 'Ports'],
+        listPrinters() {
+          return print.listPrinters();
+        },
+        install(printer: PrinterDefinition) {
+          print.installPrinter(normalizePrinter(printer));
+        },
+        uninstall(id: string) {
+          print.removePrinter(id);
+        },
+        submitTestPage(printerId: string) {
+          return print.submitJob({
+            printerId,
+            documentName: 'Windows 95 Printer Test Page',
+            content: 'Windows 95 Printer Test Page\n-----------------------------\nThis is a simulated test page.',
+          });
+        },
+        listJobs(printerId?: string) {
+          return print.listJobs(printerId);
+        },
+        pause(jobId: string) {
+          return print.pauseJob(jobId);
+        },
+        resume(jobId: string) {
+          return print.resumeJob(jobId);
+        },
+        cancel(jobId: string) {
+          return print.cancelJob(jobId);
+        },
+        dispose() {
+          // Nothing to dispose yet.
+        },
+      };
+    },
+  };
+}

--- a/win95sim_v2/src/apps/system/control-panel/applets/sounds/index.ts
+++ b/win95sim_v2/src/apps/system/control-panel/applets/sounds/index.ts
@@ -1,0 +1,62 @@
+import type { ControlPanelApplet, ControlPanelContext, SoundsAppletSession } from '../../types';
+import type { ControlPanelManifestEntry } from '../../manifest';
+
+const ENABLED_KEY = 'audio.enabled';
+const SCHEME_KEY = 'audio.scheme';
+const DEFAULT_SCHEME = 'Windows Default';
+
+export function createApplet(
+  context: ControlPanelContext,
+  manifest: ControlPanelManifestEntry,
+): ControlPanelApplet<SoundsAppletSession> {
+  const { settings } = context;
+
+  return {
+    id: `control-panel/${manifest.id}`,
+    title: manifest.title,
+    description: manifest.description,
+    category: manifest.category,
+    keywords: [...manifest.keywords],
+    manifest,
+    open(): SoundsAppletSession {
+      const initialEnabled = Boolean(settings.get(ENABLED_KEY, true));
+      const initialScheme = String(settings.get(SCHEME_KEY, DEFAULT_SCHEME) ?? DEFAULT_SCHEME);
+      let enabled = initialEnabled;
+      let scheme = initialScheme;
+
+      return {
+        tabs: ['Sounds', 'Schemes'],
+        isEnabled() {
+          return enabled;
+        },
+        setEnabled(next: boolean) {
+          enabled = !!next;
+        },
+        getScheme() {
+          return scheme;
+        },
+        setScheme(next: string) {
+          scheme = next.trim() || DEFAULT_SCHEME;
+        },
+        preview(event: string) {
+          if (!enabled) {
+            return null;
+          }
+          return `${scheme}:${event}`;
+        },
+        apply() {
+          settings.set(ENABLED_KEY, enabled);
+          settings.set(SCHEME_KEY, scheme);
+        },
+        reset() {
+          enabled = Boolean(settings.get(ENABLED_KEY, initialEnabled));
+          scheme = String(settings.get(SCHEME_KEY, initialScheme) ?? initialScheme);
+        },
+        dispose() {
+          enabled = initialEnabled;
+          scheme = initialScheme;
+        },
+      };
+    },
+  };
+}

--- a/win95sim_v2/src/apps/system/control-panel/control-panel.manifest.json
+++ b/win95sim_v2/src/apps/system/control-panel/control-panel.manifest.json
@@ -1,0 +1,52 @@
+{
+  "applets": [
+    {
+      "id": "display",
+      "title": "Display",
+      "description": "Adjust screen resolution and scaling options.",
+      "category": "Appearance",
+      "keywords": ["display", "resolution", "wallpaper", "color"],
+      "module": "@apps/system/control-panel/applets/display"
+    },
+    {
+      "id": "date-time",
+      "title": "Date/Time",
+      "description": "Set the system clock and time zone offset.",
+      "category": "System",
+      "keywords": ["clock", "timezone", "calendar"],
+      "module": "@apps/system/control-panel/applets/dateTime"
+    },
+    {
+      "id": "keyboard",
+      "title": "Keyboard",
+      "description": "Configure repeat rate and delay for keys.",
+      "category": "Hardware",
+      "keywords": ["keyboard", "repeat", "delay"],
+      "module": "@apps/system/control-panel/applets/input"
+    },
+    {
+      "id": "mouse",
+      "title": "Mouse",
+      "description": "Change pointer speed and double-click detection.",
+      "category": "Hardware",
+      "keywords": ["mouse", "pointer", "doubleclick"],
+      "module": "@apps/system/control-panel/applets/mouse"
+    },
+    {
+      "id": "sounds",
+      "title": "Sounds",
+      "description": "Toggle sound schemes and audio playback.",
+      "category": "Multimedia",
+      "keywords": ["audio", "scheme", "sound"],
+      "module": "@apps/system/control-panel/applets/sounds"
+    },
+    {
+      "id": "printers",
+      "title": "Printers",
+      "description": "Manage installed printers and queued jobs.",
+      "category": "Hardware",
+      "keywords": ["printer", "queue", "spool"],
+      "module": "@apps/system/control-panel/applets/printers"
+    }
+  ]
+}

--- a/win95sim_v2/src/apps/system/control-panel/index.ts
+++ b/win95sim_v2/src/apps/system/control-panel/index.ts
@@ -1,0 +1,68 @@
+import type { ModuleRegistry } from '@core/kernel/moduleRegistry';
+import { getControlPanelManifest, type ControlPanelManifestEntry } from './manifest';
+import type { ControlPanelApplet, ControlPanelAppletModule, ControlPanelContext } from './types';
+
+export type ControlPanelModuleLoader = (
+  request: string,
+) => Promise<ControlPanelAppletModule> | ControlPanelAppletModule;
+
+export interface RegisterControlPanelOptions {
+  loader?: ControlPanelModuleLoader;
+  manifest?: ControlPanelManifestEntry[];
+  version?: string;
+}
+
+function ensureLoader(module: unknown): ControlPanelAppletModule {
+  if (!module || typeof module !== 'object') {
+    throw new Error('Control Panel applet module must export createApplet(context, manifest)');
+  }
+
+  const candidate = module as ControlPanelAppletModule;
+  if (typeof candidate.createApplet !== 'function') {
+    throw new Error('Control Panel applet module missing createApplet export');
+  }
+
+  return candidate;
+}
+
+async function resolveModule(
+  loader: ControlPanelModuleLoader,
+  moduleId: string,
+): Promise<ControlPanelAppletModule> {
+  const loaded = await loader(moduleId);
+  return ensureLoader(loaded);
+}
+
+async function defaultLoader(moduleId: string): Promise<ControlPanelAppletModule> {
+  const loaded = await import(/* @vite-ignore */ moduleId);
+  return ensureLoader(loaded);
+}
+
+export async function registerControlPanelApplets(
+  registry: ModuleRegistry,
+  context: ControlPanelContext,
+  options: RegisterControlPanelOptions = {},
+): Promise<ControlPanelApplet[]> {
+  const manifest = options.manifest ?? getControlPanelManifest();
+  const loader = options.loader ?? defaultLoader;
+  const version = options.version ?? '2.0.0';
+  const registered: ControlPanelApplet[] = [];
+
+  for (const entry of manifest) {
+    const module = await resolveModule(loader, entry.module);
+    const appletId = `apps/control-panel/${entry.id}`;
+    const instance = module.createApplet(context, entry);
+    registered.push(instance);
+
+    registry.register({
+      id: appletId,
+      version,
+      factory: () => instance,
+    });
+  }
+
+  return registered;
+}
+
+export * from './types';
+export * from './manifest';

--- a/win95sim_v2/src/apps/system/control-panel/manifest.ts
+++ b/win95sim_v2/src/apps/system/control-panel/manifest.ts
@@ -1,0 +1,42 @@
+import manifest from './control-panel.manifest.json';
+
+export interface ControlPanelManifestEntry {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  keywords: string[];
+  module: string;
+}
+
+export interface ControlPanelManifest {
+  applets: ControlPanelManifestEntry[];
+}
+
+function normalizeManifest(data: ControlPanelManifest): ControlPanelManifestEntry[] {
+  const seen = new Set<string>();
+  return data.applets.map((entry) => {
+    const id = entry.id.trim();
+    if (!id) {
+      throw new Error('Control Panel applet id cannot be empty');
+    }
+    if (seen.has(id)) {
+      throw new Error(`Duplicate Control Panel applet id detected: ${id}`);
+    }
+    seen.add(id);
+    return {
+      ...entry,
+      id,
+      title: entry.title.trim(),
+      description: entry.description.trim(),
+      category: entry.category.trim(),
+      keywords: entry.keywords.map((keyword) => keyword.trim()).filter(Boolean),
+    };
+  });
+}
+
+const CONTROL_PANEL_MANIFEST: ControlPanelManifestEntry[] = normalizeManifest(manifest as ControlPanelManifest);
+
+export function getControlPanelManifest(): ControlPanelManifestEntry[] {
+  return CONTROL_PANEL_MANIFEST.map((entry) => ({ ...entry, keywords: [...entry.keywords] }));
+}

--- a/win95sim_v2/src/apps/system/control-panel/types.ts
+++ b/win95sim_v2/src/apps/system/control-panel/types.ts
@@ -1,0 +1,87 @@
+import type { DisplayService, DisplayState, ScalingMode } from '@services/display';
+import type { SettingsService } from '@services/settings';
+import type { PrintService } from '@services/print';
+import type { ControlPanelManifestEntry } from './manifest';
+
+export interface ControlPanelContext {
+  display: DisplayService;
+  settings: SettingsService;
+  print: PrintService;
+}
+
+export interface ControlPanelAppletSession {
+  tabs: string[];
+  dispose(): void;
+}
+
+export interface DisplayAppletSession extends ControlPanelAppletSession {
+  state: {
+    applied: DisplayState;
+    pending: DisplayState;
+  };
+  previewResolution(width: number, height: number): void;
+  setScalingMode(mode: ScalingMode): void;
+  toggleIntegerScale(enabled: boolean): void;
+  apply(): void;
+  cancel(): void;
+}
+
+export interface DateTimeAppletSession extends ControlPanelAppletSession {
+  getOffsetMinutes(): number;
+  setOffsetMinutes(minutes: number): void;
+  apply(): void;
+  reset(): void;
+}
+
+export interface InputAppletSession extends ControlPanelAppletSession {
+  getRepeatRate(): number;
+  setRepeatRate(rate: number): void;
+  getDelay(): number;
+  setDelay(delay: number): void;
+  apply(): void;
+  reset(): void;
+}
+
+export interface MouseAppletSession extends ControlPanelAppletSession {
+  getPointerSpeed(): number;
+  setPointerSpeed(speed: number): void;
+  getDoubleClickSpeed(): number;
+  setDoubleClickSpeed(speed: number): void;
+  apply(): void;
+  reset(): void;
+}
+
+export interface SoundsAppletSession extends ControlPanelAppletSession {
+  isEnabled(): boolean;
+  setEnabled(enabled: boolean): void;
+  getScheme(): string;
+  setScheme(scheme: string): void;
+  preview(event: string): string | null;
+  apply(): void;
+  reset(): void;
+}
+
+export interface PrintersAppletSession extends ControlPanelAppletSession {
+  listPrinters(): ReturnType<ControlPanelContext['print']['listPrinters']>;
+  install(printer: Parameters<ControlPanelContext['print']['installPrinter']>[0]): void;
+  uninstall(id: string): void;
+  submitTestPage(printerId: string): ReturnType<ControlPanelContext['print']['submitJob']>;
+  listJobs(printerId?: string): ReturnType<ControlPanelContext['print']['listJobs']>;
+  pause(jobId: string): ReturnType<ControlPanelContext['print']['pauseJob']>;
+  resume(jobId: string): ReturnType<ControlPanelContext['print']['resumeJob']>;
+  cancel(jobId: string): ReturnType<ControlPanelContext['print']['cancelJob']>;
+}
+
+export interface ControlPanelApplet<TSession extends ControlPanelAppletSession = ControlPanelAppletSession> {
+  id: string;
+  title: string;
+  description?: string;
+  category: string;
+  keywords: string[];
+  manifest: ControlPanelManifestEntry;
+  open(): TSession;
+}
+
+export interface ControlPanelAppletModule<TSession extends ControlPanelAppletSession = ControlPanelAppletSession> {
+  createApplet(context: ControlPanelContext, manifest: ControlPanelManifestEntry): ControlPanelApplet<TSession>;
+}

--- a/win95sim_v2/src/services/print/index.ts
+++ b/win95sim_v2/src/services/print/index.ts
@@ -1,0 +1,290 @@
+import { createEventBus } from '@core/kernel/eventBus';
+import {
+  PrintJob,
+  PrintJobRequest,
+  PrintService,
+  PrintSpooler,
+  PrinterDefinition,
+  PrintSpoolResult,
+} from './types';
+import { createMemorySpooler } from './spooler';
+
+export interface CreatePrintServiceOptions {
+  printers?: PrinterDefinition[];
+  spooler?: PrintSpooler;
+  now?: () => number;
+  autoProcess?: boolean;
+}
+
+const DEFAULT_PRINTERS: PrinterDefinition[] = [
+  {
+    id: 'printer:generic-text',
+    name: 'Generic / Text Only',
+    driver: 'generic-text',
+    description: 'Renders plain text output for debugging layouts.',
+    isDefault: true,
+    capabilities: ['text', 'monochrome'],
+  },
+  {
+    id: 'printer:virtual-pdf',
+    name: 'WinPrint PDF Writer',
+    driver: 'virtual-pdf',
+    description: 'Generates PDF output in the virtual spool folder.',
+    capabilities: ['text', 'graphics', 'pdf'],
+  },
+];
+
+interface InternalJobRecord extends PrintJob {
+  _queueIndex: number;
+}
+
+export function createPrintService(options: CreatePrintServiceOptions = {}): PrintService {
+  const now = options.now ?? (() => Date.now());
+  const bus = createEventBus();
+  const spooler = options.spooler ?? createMemorySpooler();
+  const printers = new Map<string, PrinterDefinition>();
+  const jobs = new Map<string, InternalJobRecord>();
+  const queue: string[] = [];
+  let jobCounter = 0;
+
+  function emit(type: string, payload: unknown) {
+    bus.emit(type, payload);
+  }
+
+  function cloneJob(job: InternalJobRecord): PrintJob {
+    const { _queueIndex, ...rest } = job;
+    return { ...rest };
+  }
+
+  function ensurePrinter(id: string) {
+    const printer = printers.get(id);
+    if (!printer) {
+      throw new Error(`Printer with id "${id}" is not installed`);
+    }
+    return printer;
+  }
+
+  function installDefaults() {
+    for (const printer of options.printers ?? DEFAULT_PRINTERS) {
+      installPrinter(printer);
+    }
+  }
+
+  function installPrinter(printer: PrinterDefinition): PrinterDefinition {
+    if (printers.has(printer.id)) {
+      throw new Error(`Printer with id "${printer.id}" is already installed`);
+    }
+
+    printers.set(printer.id, { ...printer });
+    emit('print:printer-changed', { action: 'installed', printer: { ...printer } });
+    return getPrinter(printer.id)!;
+  }
+
+  function removePrinter(id: string): PrinterDefinition | undefined {
+    const existing = printers.get(id);
+    if (!existing) {
+      return undefined;
+    }
+
+    printers.delete(id);
+    for (const job of jobs.values()) {
+      if (job.printerId === id && job.status !== 'completed' && job.status !== 'cancelled') {
+        job.status = 'cancelled';
+        job.updatedAt = now();
+        emit('print:job-updated', { job: cloneJob(job) });
+      }
+    }
+    emit('print:printer-changed', { action: 'removed', printer: { ...existing } });
+    return { ...existing };
+  }
+
+  function getPrinter(id: string) {
+    const printer = printers.get(id);
+    return printer ? { ...printer } : undefined;
+  }
+
+  function listPrinters() {
+    return Array.from(printers.values())
+      .map((printer) => ({ ...printer }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  function enqueue(job: InternalJobRecord) {
+    job._queueIndex = queue.push(job.id) - 1;
+  }
+
+  function takeNextQueuedJob(): InternalJobRecord | undefined {
+    while (queue.length) {
+      const jobId = queue.shift();
+      if (!jobId) {
+        continue;
+      }
+      const job = jobs.get(jobId);
+      if (!job) {
+        continue;
+      }
+      if (job.status !== 'queued') {
+        continue;
+      }
+      job._queueIndex = -1;
+      return job;
+    }
+    return undefined;
+  }
+
+  function markUpdated(job: InternalJobRecord, event: 'print:job-updated' | 'print:job-completed' | 'print:job-error') {
+    job.updatedAt = now();
+    emit(event, { job: cloneJob(job) });
+  }
+
+  function processJob(job: InternalJobRecord): InternalJobRecord {
+    if (job.status !== 'queued') {
+      return job;
+    }
+
+    job.status = 'printing';
+    markUpdated(job, 'print:job-updated');
+
+    try {
+      const result: PrintSpoolResult = spooler.write(job, job.content);
+      job.outputPath = result.path;
+      job.status = 'completed';
+      job.completedAt = now();
+      markUpdated(job, 'print:job-completed');
+    } catch (error) {
+      job.status = 'error';
+      job.error = error instanceof Error ? error.message : String(error);
+      markUpdated(job, 'print:job-error');
+    }
+
+    return job;
+  }
+
+  function processNextJob(): PrintJob | undefined {
+    const job = takeNextQueuedJob();
+    if (!job) {
+      return undefined;
+    }
+    const processed = processJob(job);
+    return cloneJob(processed);
+  }
+
+  function processAllJobs(): PrintJob[] {
+    const results: PrintJob[] = [];
+    let job: PrintJob | undefined;
+    while ((job = processNextJob())) {
+      results.push(job);
+    }
+    return results;
+  }
+
+  function submitJob(request: PrintJobRequest): PrintJob {
+    ensurePrinter(request.printerId);
+    const createdAt = now();
+    const job: InternalJobRecord = {
+      id: `job-${++jobCounter}`,
+      printerId: request.printerId,
+      documentName: request.documentName,
+      copies: request.copies ?? 1,
+      content: request.content,
+      contentType: request.contentType ?? 'text/plain',
+      status: 'queued',
+      outputPath: undefined,
+      error: undefined,
+      createdAt,
+      updatedAt: createdAt,
+      completedAt: undefined,
+      _queueIndex: -1,
+    };
+
+    jobs.set(job.id, job);
+    enqueue(job);
+    emit('print:job-submitted', { job: cloneJob(job) });
+
+    if (options.autoProcess !== false) {
+      processAllJobs();
+    }
+
+    return cloneJob(job);
+  }
+
+  function getJob(id: string) {
+    const job = jobs.get(id);
+    return job ? cloneJob(job) : undefined;
+  }
+
+  function listJobs(printerId?: string) {
+    const items = Array.from(jobs.values())
+      .filter((job) => !printerId || job.printerId === printerId)
+      .map((job) => cloneJob(job));
+    return items.sort((a, b) => a.createdAt - b.createdAt);
+  }
+
+  function updateQueue(job: InternalJobRecord) {
+    if (job.status === 'queued' && job._queueIndex === -1) {
+      enqueue(job);
+    }
+  }
+
+  function pauseJob(id: string) {
+    const job = jobs.get(id);
+    if (!job) {
+      return undefined;
+    }
+    if (job.status === 'queued' || job.status === 'printing') {
+      job.status = 'paused';
+      markUpdated(job, 'print:job-updated');
+    }
+    return cloneJob(job);
+  }
+
+  function resumeJob(id: string) {
+    const job = jobs.get(id);
+    if (!job) {
+      return undefined;
+    }
+    if (job.status === 'paused') {
+      job.status = 'queued';
+      markUpdated(job, 'print:job-updated');
+      updateQueue(job);
+      if (options.autoProcess !== false) {
+        processAllJobs();
+      }
+    }
+    return cloneJob(job);
+  }
+
+  function cancelJob(id: string) {
+    const job = jobs.get(id);
+    if (!job) {
+      return undefined;
+    }
+    if (job.status === 'queued' || job.status === 'paused') {
+      job.status = 'cancelled';
+      markUpdated(job, 'print:job-updated');
+    }
+    return cloneJob(job);
+  }
+
+  installDefaults();
+
+  return {
+    listPrinters,
+    getPrinter,
+    installPrinter,
+    removePrinter,
+    submitJob,
+    getJob,
+    listJobs,
+    pauseJob,
+    resumeJob,
+    cancelJob,
+    processNextJob,
+    processAllJobs,
+    bus,
+  };
+}
+
+export type { PrintJob, PrintJobRequest, PrintService, PrinterDefinition } from './types';
+export { createMemorySpooler } from './spooler';
+export type { MemorySpooler, SpoolRecord } from './spooler';

--- a/win95sim_v2/src/services/print/spooler.ts
+++ b/win95sim_v2/src/services/print/spooler.ts
@@ -1,0 +1,55 @@
+import { PrintJob, PrintSpoolResult, PrintSpooler } from './types';
+
+export interface SpoolRecord extends PrintSpoolResult {
+  jobId: string;
+  printerId: string;
+  createdAt: number;
+  content: string;
+}
+
+export interface MemorySpooler extends PrintSpooler {
+  read(path: string): string | undefined;
+  list(): SpoolRecord[];
+  clear(): void;
+}
+
+export interface MemorySpoolerOptions {
+  root?: string;
+  clock?: () => number;
+}
+
+function sanitize(segment: string) {
+  return segment.replace(/[^a-z0-9_-]+/gi, '-');
+}
+
+export function createMemorySpooler(options: MemorySpoolerOptions = {}): MemorySpooler {
+  const root = options.root ?? '/vfs/spool';
+  const clock = options.clock ?? (() => Date.now());
+  const records = new Map<string, SpoolRecord>();
+
+  return {
+    write(job: PrintJob, content: string): PrintSpoolResult {
+      const jobSegment = `${sanitize(job.printerId)}-${sanitize(job.id)}`;
+      const path = `${root}/${jobSegment}.${job.contentType.includes('pdf') ? 'pdf' : 'txt'}`;
+      const record: SpoolRecord = {
+        jobId: job.id,
+        printerId: job.printerId,
+        mimeType: job.contentType,
+        path,
+        content,
+        createdAt: clock(),
+      };
+      records.set(path, record);
+      return { path, mimeType: record.mimeType };
+    },
+    read(path) {
+      return records.get(path)?.content;
+    },
+    list() {
+      return Array.from(records.values()).sort((a, b) => a.createdAt - b.createdAt);
+    },
+    clear() {
+      records.clear();
+    },
+  };
+}

--- a/win95sim_v2/src/services/print/types.ts
+++ b/win95sim_v2/src/services/print/types.ts
@@ -1,0 +1,85 @@
+import type { EventBus } from '@core/kernel/eventBus';
+
+export type PrinterDriver = 'generic-text' | 'virtual-pdf';
+
+export interface PrinterDefinition {
+  id: string;
+  name: string;
+  driver: PrinterDriver;
+  description?: string;
+  isDefault?: boolean;
+  capabilities?: string[];
+}
+
+export type PrintJobStatus =
+  | 'queued'
+  | 'printing'
+  | 'paused'
+  | 'completed'
+  | 'cancelled'
+  | 'error';
+
+export interface PrintJobRequest {
+  printerId: string;
+  documentName: string;
+  content: string;
+  copies?: number;
+  contentType?: string;
+}
+
+export interface PrintJob {
+  id: string;
+  printerId: string;
+  documentName: string;
+  status: PrintJobStatus;
+  copies: number;
+  content: string;
+  contentType: string;
+  outputPath?: string;
+  error?: string;
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+}
+
+export interface PrintSpoolResult {
+  path: string;
+  mimeType: string;
+}
+
+export interface PrintSpooler {
+  write(job: PrintJob, content: string): PrintSpoolResult;
+}
+
+export interface PrintJobEvent {
+  job: PrintJob;
+}
+
+export interface PrintPrinterEvent {
+  action: 'installed' | 'removed' | 'updated';
+  printer: PrinterDefinition;
+}
+
+export interface PrintServiceEvents {
+  'print:job-submitted': PrintJobEvent;
+  'print:job-updated': PrintJobEvent;
+  'print:job-completed': PrintJobEvent;
+  'print:job-error': PrintJobEvent;
+  'print:printer-changed': PrintPrinterEvent;
+}
+
+export interface PrintService {
+  listPrinters(): PrinterDefinition[];
+  getPrinter(id: string): PrinterDefinition | undefined;
+  installPrinter(printer: PrinterDefinition): PrinterDefinition;
+  removePrinter(id: string): PrinterDefinition | undefined;
+  submitJob(request: PrintJobRequest): PrintJob;
+  getJob(id: string): PrintJob | undefined;
+  listJobs(printerId?: string): PrintJob[];
+  pauseJob(id: string): PrintJob | undefined;
+  resumeJob(id: string): PrintJob | undefined;
+  cancelJob(id: string): PrintJob | undefined;
+  processNextJob(): PrintJob | undefined;
+  processAllJobs(): PrintJob[];
+  bus: EventBus;
+}

--- a/win95sim_v2/tests/phase08-control-panel.test.js
+++ b/win95sim_v2/tests/phase08-control-panel.test.js
@@ -1,11 +1,196 @@
 const test = require('node:test');
+const assert = require('node:assert/strict');
+const { loadModule } = require('./helpers/loadModule');
 
-// Placeholder suite for Control Panel and device management features.
+function resolveAppletModule(request) {
+  if (!request.startsWith('@apps/')) {
+    throw new Error(`Unsupported module request: ${request}`);
+  }
 
-test('control panel loads applets dynamically', (t) => {
-  t.todo('assert module manifests register correctly');
+  const relative = request.replace(/^@apps\//, 'src/apps/');
+
+  try {
+    return loadModule(`${relative}.ts`);
+  } catch (error) {
+    return loadModule(`${relative}/index.ts`);
+  }
+}
+
+test('control panel loads applets dynamically', async () => {
+  const { createModuleRegistry } = loadModule('src/core/kernel/moduleRegistry.ts');
+  const {
+    registerControlPanelApplets,
+    getControlPanelManifest,
+  } = loadModule('src/apps/system/control-panel/index.ts');
+  const { createDisplayService } = loadModule('src/services/display/index.ts');
+  const { createSettingsService } = loadModule('src/services/settings/index.ts');
+  const {
+    createPrintService,
+    createMemorySpooler,
+  } = loadModule('src/services/print/index.ts');
+
+  const registry = createModuleRegistry();
+  const display = createDisplayService();
+  const settings = createSettingsService();
+  const spooler = createMemorySpooler({ root: '/test/spool', clock: (() => {
+    let tick = 0;
+    return () => ++tick;
+  })() });
+  const print = createPrintService({ spooler, autoProcess: false, now: (() => {
+    let tick = 0;
+    return () => ++tick;
+  })() });
+
+  const manifest = getControlPanelManifest();
+  const applets = await registerControlPanelApplets(
+    registry,
+    { display, settings, print },
+    { loader: resolveAppletModule },
+  );
+
+  assert.equal(applets.length, manifest.length);
+
+  const registeredIds = registry
+    .list()
+    .filter((id) => id.startsWith('apps/control-panel/'));
+  const expectedIds = manifest
+    .map((entry) => `apps/control-panel/${entry.id}`)
+    .sort();
+  assert.deepStrictEqual(registeredIds, expectedIds);
+
+  const displayApplet = registry.resolve('apps/control-panel/display');
+  const displaySession = displayApplet.open();
+  assert.deepStrictEqual(displaySession.tabs, ['Background', 'Screen Saver', 'Appearance', 'Settings']);
+
+  assert.equal(displaySession.state.applied.width, 640);
+  displaySession.previewResolution(1024, 768);
+  assert.equal(displaySession.state.pending.width, 1024);
+  assert.equal(display.getState().width, 640, 'pending state should not mutate display service');
+  displaySession.setScalingMode('pixel');
+  displaySession.toggleIntegerScale(false);
+  displaySession.apply();
+  assert.equal(display.getState().width, 1024);
+  assert.equal(display.getState().scalingMode, 'pixel');
+  assert.equal(display.getState().integerScale, false);
+  displaySession.previewResolution(300, 10000);
+  assert.equal(displaySession.state.pending.height, 1536, 'height should be clamped');
+  displaySession.cancel();
+  assert.equal(displaySession.state.pending.width, 1024, 'cancel restores applied state');
+
+  const dateTimeApplet = registry.resolve('apps/control-panel/date-time');
+  const dateTimeSession = dateTimeApplet.open();
+  assert.equal(dateTimeSession.getOffsetMinutes(), 0);
+  dateTimeSession.setOffsetMinutes(95.7);
+  dateTimeSession.apply();
+  assert.equal(settings.get('time.offsetMinutes'), 96);
+  dateTimeSession.setOffsetMinutes(-2000);
+  assert.equal(dateTimeSession.getOffsetMinutes(), -720, 'offset is clamped to minimum');
+  dateTimeSession.reset();
+  assert.equal(dateTimeSession.getOffsetMinutes(), 96, 'reset restores stored value');
+
+  const soundsApplet = registry.resolve('apps/control-panel/sounds');
+  const soundsSession = soundsApplet.open();
+  assert.equal(soundsSession.preview('open'), 'Windows Default:open');
+  soundsSession.setEnabled(false);
+  assert.equal(soundsSession.preview('close'), null, 'preview disabled when audio muted');
+  soundsSession.setScheme('Sci-Fi');
+  soundsSession.apply();
+  assert.equal(settings.get('audio.scheme'), 'Sci-Fi');
+  soundsSession.reset();
+  assert.equal(soundsSession.getScheme(), 'Sci-Fi', 'reset pulls scheme from settings');
+
+  const printersApplet = registry.resolve('apps/control-panel/printers');
+  const printersSession = printersApplet.open();
+  const printerList = printersSession.listPrinters();
+  assert.ok(printerList.some((printer) => printer.id === 'printer:generic-text'));
+  const job = printersSession.submitTestPage('printer:generic-text');
+  assert.equal(job.status, 'queued');
+  const processed = print.processNextJob();
+  assert(processed);
+  assert.equal(processed.status, 'completed');
+  assert.ok(processed.outputPath);
+  assert.equal(spooler.read(processed.outputPath), job.content);
+
+  const queued = printersSession.submitTestPage('printer:generic-text');
+  printersSession.pause(queued.id);
+  assert.equal(print.getJob(queued.id).status, 'paused');
+  printersSession.resume(queued.id);
+  assert.equal(print.getJob(queued.id).status, 'queued');
+  print.processNextJob();
+
+  const cancelled = printersSession.submitTestPage('printer:generic-text');
+  printersSession.cancel(cancelled.id);
+  assert.equal(print.getJob(cancelled.id).status, 'cancelled');
+
+  printersSession.install({
+    id: 'printer:deskjet',
+    name: 'HP DeskJet',
+    driver: 'generic-text',
+  });
+  assert.ok(printersSession.listPrinters().some((printer) => printer.id === 'printer:deskjet'));
+  printersSession.uninstall('printer:deskjet');
+  assert.ok(!printersSession.listPrinters().some((printer) => printer.id === 'printer:deskjet'));
 });
 
-test('printer manager queues jobs', (t) => {
-  t.todo('simulate device service once available');
+test('printer manager queues jobs', () => {
+  const {
+    createPrintService,
+    createMemorySpooler,
+  } = loadModule('src/services/print/index.ts');
+
+  let tick = 0;
+  const clock = () => ++tick;
+  const spooler = createMemorySpooler({ root: '/queue/spool', clock });
+  const service = createPrintService({ spooler, autoProcess: false, now: clock });
+
+  const events = [];
+  service.bus.on('print:job-updated', (event) => events.push({ type: 'updated', status: event.job.status }));
+  service.bus.on('print:job-completed', (event) => events.push({ type: 'completed', status: event.job.status }));
+
+  const job1 = service.submitJob({
+    printerId: 'printer:generic-text',
+    documentName: 'Doc 1',
+    content: 'alpha',
+  });
+  assert.equal(job1.status, 'queued');
+  const finished1 = service.processNextJob();
+  assert(finished1);
+  assert.equal(finished1.status, 'completed');
+  assert.equal(spooler.read(finished1.outputPath), 'alpha');
+
+  const job2 = service.submitJob({
+    printerId: 'printer:generic-text',
+    documentName: 'Doc 2',
+    content: 'beta',
+  });
+  service.pauseJob(job2.id);
+  assert.equal(service.getJob(job2.id).status, 'paused');
+  service.resumeJob(job2.id);
+  const finished2 = service.processNextJob();
+  assert(finished2);
+  assert.equal(finished2.status, 'completed');
+
+  const job3 = service.submitJob({
+    printerId: 'printer:generic-text',
+    documentName: 'Doc 3',
+    content: 'gamma',
+  });
+  service.cancelJob(job3.id);
+  assert.equal(service.getJob(job3.id).status, 'cancelled');
+  assert.equal(service.processNextJob(), undefined, 'cancelled job should not process');
+
+  const job4 = service.submitJob({
+    printerId: 'printer:virtual-pdf',
+    documentName: 'Doc 4',
+    content: 'delta',
+    contentType: 'application/pdf',
+  });
+  service.pauseJob(job4.id);
+  service.removePrinter('printer:virtual-pdf');
+  assert.equal(service.getJob(job4.id).status, 'cancelled', 'removing printer cancels pending jobs');
+
+  const statuses = events.map((event) => event.status);
+  assert.ok(statuses.includes('completed'));
+  assert.ok(statuses.every((status) => ['queued', 'printing', 'completed', 'paused', 'cancelled', 'error'].includes(status)));
+  assert.ok(service.listPrinters().every((printer) => printer.id.startsWith('printer:')));
 });


### PR DESCRIPTION
## Summary
- add a manifest-driven control panel module with display, date/time, input, mouse, sounds, and printers applets
- implement the print service queue and memory spooler alongside documentation for extending the control panel
- expand the phase 08 test suite to exercise control panel workflows and the print queue lifecycle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f65c6c570483299d0c9c9b2caf4510