### PR TITLE
Phase 09: add theme and localization services

### DIFF
--- a/win95sim_v2/docs/experience-extensibility.md
+++ b/win95sim_v2/docs/experience-extensibility.md
@@ -1,0 +1,60 @@
+# Experience Extensibility Guide
+
+Phase 09 introduces the shared services that allow contributors to add themes,
+locales, and experience plug-ins without modifying core runtime files. Follow
+the guidance below to extend the simulator safely.
+
+## Adding a theme
+
+1. **Create a theme manifest** – Add a JSON file under `src/styles/themes/`
+   describing the theme. Each manifest should provide an `id`, human readable
+   `label`, optional `metadata`, and a map of CSS custom property overrides via
+   `tokens`.
+   ```json
+   {
+     "id": "sunset",
+     "label": "Sunset",
+     "tokens": {
+       "--win95-color-window": "#f5d7b2",
+       "--win95-color-highlight": "#d14a00"
+     }
+   }
+   ```
+2. **Register the theme** – Themes are managed by `createThemeService`. Pass
+   your manifest when constructing the service or call
+   `themeService.registerTheme(manifest)` at runtime. Registration throws if an
+   `id` collides, ensuring independent workstreams do not overwrite each other.
+3. **React to theme changes** – Modules can subscribe to
+   `themeService.onThemeChanged(handler)` to update UI state. The event payload
+   includes the active `theme`, `previous` theme, and whether reduced motion is
+   enabled. UI code can also read the currently applied CSS tokens from
+   `themeService.getTokens()` when computing inline styles.
+4. **Respect reduced motion** – When the accessibility toggle is enabled the
+   theme service automatically zeroes out token names starting with
+   `--motion-duration-` and marks the root element with `data-reduced-motion`.
+   Avoid reintroducing long animations in feature modules; instead, read
+   `themeService.isReducedMotionEnabled()` before starting custom transitions.
+
+## Adding a locale
+
+1. **Create a catalog** – Drop a JSON file inside `src/assets/locales/` with the
+   locale identifier, optional `direction`, and a `messages` object containing
+   key/value translations.
+2. **Expose a loader** – Provide a loader function that returns the catalog and
+   pass it to `createLocalizationService({ loaders: { 'fr-FR': () => frCatalog }})`.
+   Loaders may return a Promise for lazy imports. The default locale loader must
+   remain synchronous so boot code can translate immediately.
+3. **Translate strings** – Use `localizationService.translate(key, replacements)`
+   to access messages. Missing keys fall back to the default locale and finally
+   to the key name, so incremental catalogs do not break the shell.
+4. **Respond to locale changes** – Subscribe to
+   `localizationService.onLocaleChanged(handler)` to update UI after a user
+   switches languages. The event includes the new catalog and previous locale.
+
+## Screensavers and audio hooks
+
+Future phases will add plug-in manifests for screensavers and system sounds.
+These will follow the same pattern: JSON manifests registered through
+phase-specific services so teams can contribute assets without touching shared
+code. Until then, keep new experience features isolated under
+`src/apps/system/experience/` to avoid merge conflicts.

--- a/win95sim_v2/src/assets/locales/en-US.json
+++ b/win95sim_v2/src/assets/locales/en-US.json
@@ -1,0 +1,12 @@
+{
+  "locale": "en-US",
+  "direction": "ltr",
+  "messages": {
+    "desktop.title": "My Computer",
+    "menu.file": "File",
+    "menu.edit": "Edit",
+    "menu.view": "View",
+    "dialog.ok": "OK",
+    "dialog.cancel": "Cancel"
+  }
+}

--- a/win95sim_v2/src/assets/locales/es-ES.json
+++ b/win95sim_v2/src/assets/locales/es-ES.json
@@ -1,0 +1,9 @@
+{
+  "locale": "es-ES",
+  "direction": "ltr",
+  "messages": {
+    "desktop.title": "Mi PC",
+    "menu.file": "Archivo",
+    "menu.edit": "Editar"
+  }
+}

--- a/win95sim_v2/src/services/localization/index.ts
+++ b/win95sim_v2/src/services/localization/index.ts
@@ -1,0 +1,157 @@
+import { createEventBus, EventBus } from '@core/kernel/eventBus';
+import enUsCatalog from '../../assets/locales/en-US.json';
+import esEsCatalog from '../../assets/locales/es-ES.json';
+
+export interface LocaleCatalog {
+  locale: string;
+  direction?: 'ltr' | 'rtl';
+  messages: Record<string, string>;
+}
+
+export type LocaleLoader = () => LocaleCatalog | Promise<LocaleCatalog>;
+
+export interface LocalizationChangeEvent {
+  locale: string;
+  previous: string;
+  catalog: LocaleCatalog;
+}
+
+export interface LocalizationServiceOptions {
+  defaultLocale?: string;
+  loaders?: Record<string, LocaleLoader>;
+  bus?: EventBus;
+}
+
+export interface LocalizationService {
+  getLocale(): string;
+  listLocales(): string[];
+  getDirection(): 'ltr' | 'rtl';
+  translate(key: string, replacements?: Record<string, string>): string;
+  setLocale(locale: string): Promise<LocaleCatalog>;
+  onLocaleChanged(handler: (event: LocalizationChangeEvent) => void): () => void;
+  preload(locale: string): Promise<LocaleCatalog>;
+}
+
+const builtinLoaders: Record<string, LocaleLoader> = {
+  'en-US': () => enUsCatalog,
+  'es-ES': () => esEsCatalog,
+};
+
+export function createLocalizationService(options: LocalizationServiceOptions = {}): LocalizationService {
+  const defaultLocale = options.defaultLocale ?? 'en-US';
+  const loaders: Record<string, LocaleLoader> = { ...builtinLoaders, ...(options.loaders ?? {}) };
+  const bus = options.bus ?? createEventBus();
+
+  if (!loaders[defaultLocale]) {
+    throw new Error(`No loader registered for default locale "${defaultLocale}"`);
+  }
+
+  const catalogs = new Map<string, LocaleCatalog | Promise<LocaleCatalog>>();
+  let activeLocale = defaultLocale;
+  let activeCatalog = loadInitialCatalog(defaultLocale);
+
+  function loadInitialCatalog(locale: string) {
+    const loader = loaders[locale];
+    if (!loader) {
+      throw new Error(`No loader registered for locale "${locale}"`);
+    }
+    const result = loader();
+    if (result instanceof Promise) {
+      throw new Error('Default locale loader must return catalog synchronously');
+    }
+    catalogs.set(locale, result);
+    return result;
+  }
+
+  function getResolvedCatalog(locale: string): LocaleCatalog | undefined {
+    const value = catalogs.get(locale);
+    if (!value || value instanceof Promise) {
+      return undefined;
+    }
+    return value;
+  }
+
+  async function ensureCatalog(locale: string): Promise<LocaleCatalog> {
+    const existing = catalogs.get(locale);
+    if (existing) {
+      if (existing instanceof Promise) {
+        return existing;
+      }
+      return existing;
+    }
+
+    const loader = loaders[locale];
+    if (!loader) {
+      throw new Error(`No loader registered for locale "${locale}"`);
+    }
+
+    const pending = Promise.resolve(loader()).then((catalog) => {
+      catalogs.set(locale, catalog);
+      return catalog;
+    });
+
+    catalogs.set(locale, pending);
+    return pending;
+  }
+
+  function format(template: string, replacements?: Record<string, string>) {
+    if (!replacements) {
+      return template;
+    }
+    return Object.keys(replacements).reduce((acc, key) => acc.replace(new RegExp(`{${key}}`, 'g'), replacements[key]), template);
+  }
+
+  function translate(key: string, replacements?: Record<string, string>) {
+    const active = getResolvedCatalog(activeLocale);
+    const fallback = getResolvedCatalog(defaultLocale);
+
+    const message = active?.messages[key] ?? fallback?.messages[key];
+    if (!message) {
+      return key;
+    }
+    return format(message, replacements);
+  }
+
+  async function setLocale(locale: string): Promise<LocaleCatalog> {
+    if (locale === activeLocale) {
+      return activeCatalog;
+    }
+
+    const catalog = await ensureCatalog(locale);
+    const previous = activeLocale;
+    activeLocale = locale;
+    activeCatalog = catalog;
+    bus.emit<LocalizationChangeEvent>('localization:changed', {
+      locale: activeLocale,
+      previous,
+      catalog,
+    });
+    return catalog;
+  }
+
+  async function preload(locale: string) {
+    return ensureCatalog(locale);
+  }
+
+  function listLocales() {
+    return Object.keys(loaders).sort();
+  }
+
+  function getDirection(): 'ltr' | 'rtl' {
+    return activeCatalog.direction ?? 'ltr';
+  }
+
+  return {
+    getLocale() {
+      return activeLocale;
+    },
+    listLocales,
+    getDirection,
+    translate,
+    setLocale,
+    onLocaleChanged(handler) {
+      return bus.on('localization:changed', handler);
+    },
+    preload,
+  };
+}

--- a/win95sim_v2/src/services/theme/index.ts
+++ b/win95sim_v2/src/services/theme/index.ts
@@ -1,0 +1,275 @@
+import { createEventBus, EventBus } from '@core/kernel/eventBus';
+import type { SettingsService } from '@services/settings';
+import classicTheme from '../../styles/themes/classic.json';
+import highContrastTheme from '../../styles/themes/highContrast.json';
+
+export interface ThemeDefinitionMetadata {
+  highContrast?: boolean;
+}
+
+export interface ThemeDefinition {
+  id: string;
+  label: string;
+  tokens: Record<string, string>;
+  metadata?: ThemeDefinitionMetadata;
+}
+
+export interface ThemeChangeEvent {
+  theme: ThemeDefinition;
+  previous?: ThemeDefinition;
+  reducedMotion: boolean;
+}
+
+export interface ThemeServiceOptions {
+  themes?: ThemeDefinition[];
+  settings?: SettingsService;
+  host?: ThemeHost;
+  bus?: EventBus;
+  initialThemeId?: string;
+  reducedMotion?: boolean;
+}
+
+export interface ThemeHostContext {
+  reducedMotion: boolean;
+}
+
+export interface ThemeHost {
+  apply(theme: ThemeDefinition, tokens: Record<string, string>, context: ThemeHostContext): void;
+}
+
+export interface ThemeService {
+  listThemes(): ThemeDefinition[];
+  getTheme(id: string): ThemeDefinition | undefined;
+  getActiveTheme(): ThemeDefinition;
+  applyTheme(id: string): ThemeDefinition;
+  onThemeChanged(handler: (event: ThemeChangeEvent) => void): () => void;
+  getToken(name: string): string | undefined;
+  getTokens(): Record<string, string>;
+  registerTheme(theme: ThemeDefinition): void;
+  setReducedMotionEnabled(enabled: boolean): void;
+  isReducedMotionEnabled(): boolean;
+}
+
+const builtinThemes: ThemeDefinition[] = [classicTheme, highContrastTheme];
+
+type DocumentLike = {
+  documentElement?: {
+    style?: Record<string, string>;
+    dataset?: Record<string, string>;
+    toggleAttribute?: (name: string, force?: boolean) => void;
+  };
+  body?: {
+    style?: Record<string, string>;
+    dataset?: Record<string, string>;
+    toggleAttribute?: (name: string, force?: boolean) => void;
+  };
+};
+
+export function createCssVariableThemeHost(
+  doc: DocumentLike | undefined = typeof document !== 'undefined' ? (document as DocumentLike) : undefined,
+): ThemeHost {
+  return {
+    apply(theme, tokens, context) {
+      if (!doc) {
+        return;
+      }
+
+      const root = (doc.documentElement ?? doc.body) as
+        | {
+            style?: Record<string, string>;
+            dataset?: Record<string, string>;
+            toggleAttribute?: (name: string, force?: boolean) => void;
+          }
+        | undefined;
+
+      if (!root) {
+        return;
+      }
+
+      if (typeof root.toggleAttribute === 'function') {
+        root.toggleAttribute('data-reduced-motion', context.reducedMotion);
+      } else if (root.dataset) {
+        if (context.reducedMotion) {
+          root.dataset.reducedMotion = 'true';
+        } else {
+          delete root.dataset.reducedMotion;
+        }
+      }
+
+      if (root.dataset) {
+        root.dataset.theme = theme.id;
+        if (theme.metadata?.highContrast) {
+          root.dataset.themeContrast = 'high';
+        } else {
+          delete root.dataset.themeContrast;
+        }
+      }
+
+      const style = root.style ?? (root.style = {} as Record<string, string>);
+      Object.entries(tokens).forEach(([name, value]) => {
+        style[name] = value;
+      });
+    },
+  };
+}
+
+export function createThemeService(options: ThemeServiceOptions = {}): ThemeService {
+  const themes = new Map<string, ThemeDefinition>();
+  const order: string[] = [];
+
+  const host = options.host ?? createCssVariableThemeHost();
+  const bus = options.bus ?? createEventBus();
+  const settings = options.settings;
+
+  const providedThemes = options.themes ?? builtinThemes;
+  providedThemes.forEach((theme) => register(theme));
+
+  if (themes.size === 0) {
+    throw new Error('At least one theme must be registered');
+  }
+
+  let reducedMotion = Boolean(options.reducedMotion);
+  let activeTheme = resolveInitialTheme();
+  let activeTokens = computeTokens(activeTheme, reducedMotion);
+
+  host.apply(activeTheme, activeTokens, { reducedMotion });
+
+  if (settings) {
+    settings.watch('theme', (event) => {
+      if (typeof event.value !== 'string') {
+        return;
+      }
+      if (!themes.has(event.value) || event.value === activeTheme.id) {
+        return;
+      }
+      applyThemeInternal(event.value, { skipSettings: true });
+    });
+  }
+
+  function register(theme: ThemeDefinition) {
+    if (themes.has(theme.id)) {
+      throw new Error(`Theme with id "${theme.id}" is already registered`);
+    }
+    const frozen = {
+      ...theme,
+      tokens: { ...theme.tokens },
+      metadata: theme.metadata ? { ...theme.metadata } : undefined,
+    };
+    themes.set(frozen.id, frozen);
+    order.push(frozen.id);
+  }
+
+  function resolveInitialTheme() {
+    if (options.initialThemeId && themes.has(options.initialThemeId)) {
+      return themes.get(options.initialThemeId)!;
+    }
+
+    if (settings) {
+      const configured = settings.get('theme');
+      if (typeof configured === 'string' && themes.has(configured)) {
+        return themes.get(configured)!;
+      }
+    }
+
+    const first = themes.get(order[0]);
+    if (!first) {
+      throw new Error('Unable to determine initial theme');
+    }
+    return first;
+  }
+
+  function computeTokens(theme: ThemeDefinition, reduced: boolean) {
+    const tokens = { ...theme.tokens };
+    if (reduced) {
+      Object.keys(tokens).forEach((key) => {
+        if (key.startsWith('--motion-duration-')) {
+          tokens[key] = '0ms';
+        }
+      });
+    }
+    return tokens;
+  }
+
+  interface ApplyOptions {
+    skipSettings?: boolean;
+    emit?: boolean;
+  }
+
+  function applyThemeInternal(id: string, applyOptions: ApplyOptions = {}) {
+    const nextTheme = themes.get(id);
+    if (!nextTheme) {
+      throw new Error(`Theme "${id}" is not registered`);
+    }
+    if (nextTheme.id === activeTheme.id && applyOptions.emit !== true) {
+      return nextTheme;
+    }
+
+    const previous = activeTheme;
+    activeTheme = nextTheme;
+    activeTokens = computeTokens(activeTheme, reducedMotion);
+    host.apply(activeTheme, activeTokens, { reducedMotion });
+
+    if (!applyOptions.skipSettings && settings && settings.get('theme') !== id) {
+      settings.set('theme', id);
+    }
+
+    const shouldEmit = applyOptions.emit ?? (previous.id !== activeTheme.id || reducedMotion);
+    if (shouldEmit) {
+      bus.emit<ThemeChangeEvent>('theme:changed', {
+        theme: activeTheme,
+        previous,
+        reducedMotion,
+      });
+    }
+
+    return nextTheme;
+  }
+
+  function listThemes() {
+    return order.map((id) => themes.get(id)!);
+  }
+
+  function getTokens() {
+    return { ...activeTokens };
+  }
+
+  return {
+    listThemes,
+    getTheme(id) {
+      return themes.get(id);
+    },
+    getActiveTheme() {
+      return activeTheme;
+    },
+    applyTheme(id) {
+      return applyThemeInternal(id);
+    },
+    onThemeChanged(handler) {
+      return bus.on('theme:changed', handler);
+    },
+    getToken(name) {
+      return activeTokens[name];
+    },
+    getTokens,
+    registerTheme(theme) {
+      register(theme);
+      bus.emit('theme:registered', { theme });
+    },
+    setReducedMotionEnabled(enabled) {
+      if (reducedMotion === enabled) {
+        return;
+      }
+      reducedMotion = enabled;
+      activeTokens = computeTokens(activeTheme, reducedMotion);
+      host.apply(activeTheme, activeTokens, { reducedMotion });
+      bus.emit<ThemeChangeEvent>('theme:changed', {
+        theme: activeTheme,
+        previous: activeTheme,
+        reducedMotion,
+      });
+    },
+    isReducedMotionEnabled() {
+      return reducedMotion;
+    },
+  };
+}

--- a/win95sim_v2/src/styles/themes/classic.json
+++ b/win95sim_v2/src/styles/themes/classic.json
@@ -1,0 +1,16 @@
+{
+  "id": "classic",
+  "label": "Windows 95",
+  "tokens": {
+    "--win95-color-window": "#c3c7cb",
+    "--win95-color-windowframe": "#000000",
+    "--win95-color-highlight": "#0a64ad",
+    "--win95-color-highlight-text": "#ffffff",
+    "--win95-color-desktop": "#008080",
+    "--win95-font-ui": "'MS Sans Serif', 'Segoe UI', sans-serif",
+    "--win95-border-size": "2px",
+    "--win95-radius": "0",
+    "--motion-duration-fast": "70ms",
+    "--motion-duration-standard": "150ms"
+  }
+}

--- a/win95sim_v2/src/styles/themes/highContrast.json
+++ b/win95sim_v2/src/styles/themes/highContrast.json
@@ -1,0 +1,19 @@
+{
+  "id": "high-contrast",
+  "label": "High Contrast",
+  "metadata": {
+    "highContrast": true
+  },
+  "tokens": {
+    "--win95-color-window": "#000000",
+    "--win95-color-windowframe": "#ffffff",
+    "--win95-color-highlight": "#ffff00",
+    "--win95-color-highlight-text": "#000000",
+    "--win95-color-desktop": "#000000",
+    "--win95-font-ui": "'MS Sans Serif', 'Segoe UI', sans-serif",
+    "--win95-border-size": "2px",
+    "--win95-radius": "0",
+    "--motion-duration-fast": "70ms",
+    "--motion-duration-standard": "150ms"
+  }
+}

--- a/win95sim_v2/tests/phase09-polish.test.js
+++ b/win95sim_v2/tests/phase09-polish.test.js
@@ -1,11 +1,86 @@
 const test = require('node:test');
+const assert = require('node:assert/strict');
+const { loadModule } = require('./helpers/loadModule');
+const { withFakeDom } = require('./helpers/fakeDom');
 
-// Placeholder suite for accessibility, localization, and performance polish.
+test('high contrast theme switches CSS tokens', () => {
+  withFakeDom(() => {
+    const { createThemeService } = loadModule('src/services/theme/index.ts');
+    const { createSettingsService } = loadModule('src/services/settings/index.ts');
 
-test('high contrast theme switches CSS tokens', (t) => {
-  t.todo('assert UI updates when localization service changes theme');
+    const settings = createSettingsService({ theme: 'classic' });
+    const themeService = createThemeService({ settings });
+
+    const root = document.body;
+    assert.equal(root.dataset.theme, 'classic');
+    assert.equal(root.style['--win95-color-window'], '#c3c7cb');
+
+    const events = [];
+    const unsubscribe = themeService.onThemeChanged((event) => events.push(event));
+
+    const applied = themeService.applyTheme('high-contrast');
+    assert.equal(applied.id, 'high-contrast');
+    assert.equal(root.dataset.theme, 'high-contrast');
+    assert.equal(root.dataset.themeContrast, 'high');
+    assert.equal(root.style['--win95-color-window'], '#000000');
+    assert.equal(settings.get('theme'), 'high-contrast');
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0].theme.id, 'high-contrast');
+    assert.equal(events[0].previous.id, 'classic');
+    assert.equal(events[0].reducedMotion, false);
+
+    themeService.setReducedMotionEnabled(true);
+    assert.equal(themeService.isReducedMotionEnabled(), true);
+    assert.equal(root.attributes['data-reduced-motion'], '');
+    assert.equal(root.style['--motion-duration-fast'], '0ms');
+    assert.equal(root.style['--motion-duration-standard'], '0ms');
+
+    themeService.setReducedMotionEnabled(false);
+    assert.equal(themeService.isReducedMotionEnabled(), false);
+    assert.equal(root.attributes['data-reduced-motion'], undefined);
+    assert.equal(root.style['--motion-duration-fast'], '70ms');
+    assert.equal(root.style['--motion-duration-standard'], '150ms');
+
+    assert.equal(events.length, 3);
+    assert.equal(events[1].reducedMotion, true);
+    assert.equal(events[2].reducedMotion, false);
+
+    unsubscribe();
+  });
 });
 
-test('localization service loads language packs', (t) => {
-  t.todo('mock translation catalogs and verify fallbacks');
+test('localization service loads language packs', async () => {
+  const { createLocalizationService } = loadModule('src/services/localization/index.ts');
+
+  const service = createLocalizationService();
+  const events = [];
+  service.onLocaleChanged((event) => events.push(event));
+
+  assert.deepEqual(service.listLocales(), ['en-US', 'es-ES']);
+  assert.equal(service.getLocale(), 'en-US');
+  assert.equal(service.getDirection(), 'ltr');
+  assert.equal(service.translate('desktop.title'), 'My Computer');
+  assert.equal(service.translate('menu.view'), 'View');
+  assert.equal(service.translate('missing.key'), 'missing.key');
+
+  await service.preload('es-ES');
+
+  const esCatalog = await service.setLocale('es-ES');
+  assert.equal(esCatalog.locale, 'es-ES');
+  assert.equal(service.getLocale(), 'es-ES');
+  assert.equal(service.translate('desktop.title'), 'Mi PC');
+  assert.equal(service.translate('menu.view'), 'View');
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0].previous, 'en-US');
+  assert.equal(events[0].locale, 'es-ES');
+
+  await service.setLocale('es-ES');
+  assert.equal(events.length, 1, 'setting to the same locale should not emit');
+
+  await service.setLocale('en-US');
+  assert.equal(service.translate('desktop.title'), 'My Computer');
+  assert.equal(events.length, 2);
+  assert.equal(events[1].previous, 'es-ES');
 });


### PR DESCRIPTION
## Summary
- add a theme service with CSS-variable host support and builtin classic/high-contrast manifests
- add a localization service that loads language catalogs and emits locale change events
- document experience extensibility patterns and cover new services with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f65c6d78a08329af2b31d4c7fc3df4