### PR TITLE
Implement Phase 10 packaging pipeline

### DIFF
--- a/win95sim_v2/docs/deployment.md
+++ b/win95sim_v2/docs/deployment.md
@@ -1,0 +1,23 @@
+# Deployment Guide
+
+The single-file artifact produced by the Phase 10 packaging workflow is designed for static
+hosting platforms. Follow the steps below for common targets.
+
+## GitHub Pages
+1. Run the packaging pipeline: `npm run build && npm run release`.
+2. Copy `dist/win95sim.html` to the `docs/` directory or dedicated `gh-pages` branch.
+3. Enable GitHub Pages in repository settings and point it at the chosen branch.
+4. Optionally rename the artifact to `index.html` for automatic loading.
+
+## Netlify
+1. Upload `dist/win95sim.html` via the drag-and-drop UI or CLI.
+2. Configure a build command of `npm run build && npm run release` with `dist` as the publish directory.
+3. Attach the generated `dist/manifest.json` as a deploy note for hash verification.
+
+## npm Package
+1. Ensure `dist/win95sim.html` and `dist/manifest.json` are included in the package `files` list.
+2. Update `package.json` with the release version and run `npm publish --access public`.
+3. Provide usage instructions for consumers to serve the HTML locally or from a CDN.
+
+Always validate Subresource Integrity hashes after deployment to confirm assets were not mutated
+during upload.

--- a/win95sim_v2/docs/licenses.json
+++ b/win95sim_v2/docs/licenses.json
@@ -1,0 +1,20 @@
+{
+  "project": {
+    "name": "Win95Sim V2",
+    "license": "MIT",
+    "homepage": "https://github.com/vibeslop/win95sim_v2",
+    "copyright": "Copyright (c) 2024"
+  },
+  "dependencies": [
+    {
+      "name": "esbuild",
+      "license": "MIT",
+      "homepage": "https://esbuild.github.io"
+    },
+    {
+      "name": "TypeScript",
+      "license": "Apache-2.0",
+      "homepage": "https://www.typescriptlang.org/"
+    }
+  ]
+}

--- a/win95sim_v2/docs/module-apis-v2.md
+++ b/win95sim_v2/docs/module-apis-v2.md
@@ -187,13 +187,33 @@ Apps are declared via manifests under `apps/<name>/module.json`:
 The build pipeline validates manifests for conflicting IDs and missing permissions during Phase 01.
 
 ## Telemetry & diagnostics
-Phase 10 introduces optional telemetry via `services/diagnostics`. Until then, the interface is stubbed:
+Phase 10 introduces optional telemetry via `services/diagnostics`. The concrete implementation
+integrates with the shared settings service and exposes an opt-in workflow:
 ```ts
+interface DiagnosticsEvent {
+  event: string;
+  payload?: Record<string, unknown>;
+  timestamp: string;
+}
+
+interface DiagnosticsFlushResult {
+  events: DiagnosticsEvent[];
+  dropped: number;
+  optedIn: boolean;
+}
+
+type DiagnosticsTransport = (events: DiagnosticsEvent[]) => Promise<void> | void;
+
 interface DiagnosticsService {
   log(event: string, payload?: Record<string, unknown>): void;
-  flush(): Promise<void>;
+  flush(): Promise<DiagnosticsFlushResult>;
+  isOptedIn(): boolean;
+  configureTransport(transport: DiagnosticsTransport | undefined): void;
+  bus: EventBus;
 }
 ```
+The service monitors the `telemetry.optIn` flag in `services/settings`. Events are queued only when
+the user has opted in; otherwise they are counted as dropped for observability.
 
 ## Compatibility layer
 `core/compat/v1-adapter` exposes shims that mimic the original global functions:

--- a/win95sim_v2/docs/release-checklist.md
+++ b/win95sim_v2/docs/release-checklist.md
@@ -1,0 +1,24 @@
+# Release Checklist
+
+The packaging workflow for Phase 10 introduces an auditable checklist so release managers
+can validate artifacts before publishing.
+
+## Build Validation
+- [ ] Run `npm run build` to produce the module bundle in `dist/`.
+- [ ] Execute `npm run release` to generate `dist/win95sim.html` and `dist/manifest.json`.
+- [ ] Verify the manifest lists deterministic hashes for every bundled file.
+
+## Quality Gates
+- [ ] Confirm automated unit tests (`npm test`) pass on the release commit.
+- [ ] Perform smoke test of `dist/win95sim.html` in Chromium-based browser.
+- [ ] Capture gzip and Brotli sizes and compare against budget noted in `planning/risk-log.md`.
+
+## Documentation
+- [ ] Update `docs/deployment.md` with any host-specific instructions discovered.
+- [ ] Record release metadata in `planning/qa-checklists/phase-10.md`.
+- [ ] Append changelog entry summarizing key improvements and fixes.
+
+## Automation
+- [ ] Tag the release commit following `v<major>.<minor>.<patch>` semantics.
+- [ ] Push the tag and create a GitHub release attaching the generated manifest.
+- [ ] Trigger CI workflow `release.yml` (dry run allowed during development).

--- a/win95sim_v2/package.json
+++ b/win95sim_v2/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "node tools/build.js",
     "clean": "node tools/build.js --clean",
+    "release": "node tools/release/packager.js",
     "test": "node --test",
     "lint": "eslint \"src/**/*.{ts,tsx}\""
   },

--- a/win95sim_v2/src/apps/system/about/about.data.json
+++ b/win95sim_v2/src/apps/system/about/about.data.json
@@ -1,0 +1,10 @@
+{
+  "name": "Win95Sim V2",
+  "version": "0.1.0",
+  "generatedAt": null,
+  "manifest": {
+    "files": [],
+    "assets": []
+  },
+  "licenses": []
+}

--- a/win95sim_v2/src/services/diagnostics/index.ts
+++ b/win95sim_v2/src/services/diagnostics/index.ts
@@ -1,0 +1,110 @@
+import { createEventBus, EventBus } from '@core/kernel/eventBus';
+import { SettingsService } from '@services/settings';
+
+export interface DiagnosticsEvent {
+  event: string;
+  payload?: Record<string, unknown>;
+  timestamp: string;
+}
+
+export interface DiagnosticsFlushResult {
+  events: DiagnosticsEvent[];
+  dropped: number;
+  optedIn: boolean;
+}
+
+export interface DiagnosticsService {
+  log(event: string, payload?: Record<string, unknown>): void;
+  flush(): Promise<DiagnosticsFlushResult>;
+  isOptedIn(): boolean;
+  configureTransport(transport: DiagnosticsTransport | undefined): void;
+  bus: EventBus;
+}
+
+export type DiagnosticsTransport = (events: DiagnosticsEvent[]) => Promise<void> | void;
+
+export interface DiagnosticsServiceOptions {
+  settings?: SettingsService;
+  preferenceKey?: string;
+  transport?: DiagnosticsTransport;
+  clock?: () => Date;
+}
+
+function toBoolean(value: unknown): boolean {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    return value === 'true' || value === '1';
+  }
+
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+
+  return false;
+}
+
+export function createDiagnosticsService(options: DiagnosticsServiceOptions = {}): DiagnosticsService {
+  const { settings, preferenceKey = 'telemetry.optIn', transport, clock = () => new Date() } = options;
+  const bus = createEventBus();
+  const queue: DiagnosticsEvent[] = [];
+  let dropped = 0;
+  let activeTransport: DiagnosticsTransport | undefined = transport;
+
+  let optedIn = toBoolean(settings?.get(preferenceKey, false));
+
+  if (settings) {
+    settings.watch(preferenceKey, (event) => {
+      optedIn = toBoolean(event.value);
+      if (!optedIn) {
+        queue.length = 0;
+      }
+      bus.emit('diagnostics:opt-in-changed', { optedIn });
+    });
+  }
+
+  function log(event: string, payload?: Record<string, unknown>) {
+    const entry: DiagnosticsEvent = {
+      event,
+      payload,
+      timestamp: clock().toISOString(),
+    };
+
+    if (!optedIn) {
+      dropped += 1;
+      bus.emit('diagnostics:dropped', { event: entry });
+      return;
+    }
+
+    queue.push(entry);
+    bus.emit('diagnostics:logged', { event: entry });
+  }
+
+  async function flush(): Promise<DiagnosticsFlushResult> {
+    const events = queue.splice(0, queue.length);
+    const droppedCount = dropped;
+    dropped = 0;
+
+    if (events.length && activeTransport) {
+      await activeTransport(events);
+    }
+
+    const result: DiagnosticsFlushResult = { events, dropped: droppedCount, optedIn };
+    bus.emit('diagnostics:flushed', result);
+    return result;
+  }
+
+  return {
+    log,
+    flush,
+    isOptedIn() {
+      return optedIn;
+    },
+    configureTransport(next) {
+      activeTransport = next;
+    },
+    bus,
+  };
+}

--- a/win95sim_v2/src/shell/boot/session.ts
+++ b/win95sim_v2/src/shell/boot/session.ts
@@ -3,6 +3,7 @@ import { createEventBus } from '@core/kernel/eventBus';
 import { createSettingsService } from '@services/settings';
 import { createDisplayService } from '@services/display';
 import { createWindowService, WindowDescriptor } from '@services/window';
+import { createDiagnosticsService } from '@services/diagnostics';
 import { createWindowManager } from '@apps/shell/window-manager';
 import { createCrtViewport } from '@ui/components/crtViewport';
 import { createWindowFrame } from '@ui/components/windowFrame';
@@ -21,11 +22,13 @@ export function createShellSession(): ShellSession {
   const display = createDisplayService();
   const windows = createWindowService();
   const windowManager = createWindowManager({ display, windows, bus });
+  const diagnostics = createDiagnosticsService({ settings });
 
   registry.register({ id: 'services/settings', version: '2.0.0', factory: () => settings });
   registry.register({ id: 'services/display', version: '2.0.0', factory: () => display });
   registry.register({ id: 'services/windows', version: '2.0.0', factory: () => windows });
   registry.register({ id: 'apps/window-manager', version: '2.0.0', factory: () => windowManager });
+  registry.register({ id: 'services/diagnostics', version: '2.0.0', factory: () => diagnostics });
   registry.register({ id: 'shell/session', version: '2.0.0', factory: () => ({ bus, registry }) });
 
   let viewport: ReturnType<typeof createCrtViewport> | undefined;

--- a/win95sim_v2/tests/phase10-packaging.test.js
+++ b/win95sim_v2/tests/phase10-packaging.test.js
@@ -1,11 +1,115 @@
 const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const os = require('node:os');
+const fs = require('node:fs/promises');
 
-// Placeholder suite for packaging, telemetry opt-in, and release automation.
+const { packageRelease } = require('../tools/release/packager');
+const { loadModule } = require('./helpers/loadModule');
 
-test('build pipeline emits dist/ bundle manifest', (t) => {
-  t.todo('assert manifest includes hashes once tooling exists');
+test('build pipeline emits dist/ bundle manifest', async () => {
+  const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'win95sim-release-'));
+  const distDir = path.join(workspace, 'dist');
+  const assetsDir = path.join(distDir, 'assets');
+  await fs.mkdir(assetsDir, { recursive: true });
+
+  const initialHtml = `<!doctype html>
+<html><head><link rel="stylesheet" href="assets/app.css"></head><body><script type="module" src="assets/app.js"></script></body></html>`;
+  await fs.writeFile(path.join(distDir, 'index.html'), initialHtml, 'utf8');
+
+  const sourceManifest = {
+    script: 'assets/app.js',
+    styles: ['assets/app.css'],
+    assets: [],
+  };
+  await fs.writeFile(path.join(assetsDir, 'manifest.json'), JSON.stringify(sourceManifest, null, 2));
+  await fs.writeFile(path.join(assetsDir, 'app.js'), 'export const boot = () => console.log("hi");', 'utf8');
+  await fs.writeFile(path.join(assetsDir, 'app.css'), 'body{background:#008080;}', 'utf8');
+
+  await fs.mkdir(path.join(workspace, 'docs'), { recursive: true });
+  await fs.writeFile(
+    path.join(workspace, 'docs', 'licenses.json'),
+    JSON.stringify(
+      {
+        project: {
+          name: 'Win95Sim V2',
+          license: 'MIT',
+          homepage: 'https://example.test/win95sim',
+        },
+        dependencies: [
+          { name: 'esbuild', license: 'MIT', homepage: 'https://esbuild.github.io' },
+        ],
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  await fs.writeFile(
+    path.join(workspace, 'package.json'),
+    JSON.stringify({ name: 'win95sim-v2', version: '2.0.0' }, null, 2),
+    'utf8',
+  );
+
+  const { manifest } = await packageRelease({ rootDir: workspace });
+
+  const releaseHtml = await fs.readFile(path.join(distDir, 'win95sim.html'), 'utf8');
+  assert.ok(releaseHtml.startsWith('<!--'), 'release html includes license banner');
+  assert.ok(releaseHtml.includes('Win95Sim V2 v2.0.0') || releaseHtml.includes('Version: 2.0.0'));
+
+  const manifestPath = path.join(distDir, 'manifest.json');
+  const storedManifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+  assert.deepEqual(storedManifest, manifest);
+
+  const htmlEntry = manifest.files.find((entry) => entry.path === 'win95sim.html');
+  assert.ok(htmlEntry, 'manifest contains packaged html');
+  assert.match(htmlEntry.sha256, /^[a-f0-9]{64}$/);
+  assert.equal(typeof htmlEntry.size, 'number');
+  assert.ok(htmlEntry.size > 0);
+  assert.ok(htmlEntry.gzipSize <= htmlEntry.size);
+
+  assert.equal(manifest.assets.length, 2, 'script and stylesheet assets recorded');
+  const assetPaths = manifest.assets.map((asset) => asset.path).sort();
+  assert.deepEqual(assetPaths, ['assets/app.css', 'assets/app.js']);
+
+  const aboutDataPath = path.join(workspace, 'src/apps/system/about/about.data.json');
+  const aboutData = JSON.parse(await fs.readFile(aboutDataPath, 'utf8'));
+  assert.equal(aboutData.version, '2.0.0');
+  assert.equal(Array.isArray(aboutData.licenses), true);
+  assert.equal(aboutData.licenses.length, 2);
+  assert.equal(aboutData.manifest.files[0].path, 'win95sim.html');
 });
 
-test('telemetry service respects opt-in setting', (t) => {
-  t.todo('mock user preference store in Phase 10');
+test('telemetry service respects opt-in setting', async () => {
+  const { createSettingsService } = loadModule('src/services/settings/index.ts');
+  const { createDiagnosticsService } = loadModule('src/services/diagnostics/index.ts');
+
+  const settings = createSettingsService();
+  const diagnostics = createDiagnosticsService({ settings });
+
+  diagnostics.log('boot');
+  let flush = await diagnostics.flush();
+  assert.equal(flush.optedIn, false);
+  assert.equal(flush.events.length, 0);
+  assert.equal(flush.dropped, 1);
+
+  settings.set('telemetry.optIn', true);
+  diagnostics.log('boot', { stage: 'opted-in' });
+  diagnostics.log('window:open', { id: 'notepad' });
+  flush = await diagnostics.flush();
+  assert.equal(flush.optedIn, true);
+  assert.equal(flush.events.length, 2);
+  assert.equal(flush.dropped, 0);
+  assert.deepEqual(
+    flush.events.map((event) => event.event),
+    ['boot', 'window:open'],
+  );
+
+  settings.set('telemetry.optIn', false);
+  diagnostics.log('after-opt-out');
+  flush = await diagnostics.flush();
+  assert.equal(flush.optedIn, false);
+  assert.equal(flush.events.length, 0);
+  assert.equal(flush.dropped, 1);
 });

--- a/win95sim_v2/tools/release/packager.js
+++ b/win95sim_v2/tools/release/packager.js
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+const path = require('path');
+const fs = require('fs/promises');
+const { existsSync } = require('fs');
+const crypto = require('crypto');
+const zlib = require('zlib');
+
+function resolveRoot(rootDir) {
+  if (rootDir) {
+    return path.resolve(rootDir);
+  }
+
+  return path.resolve(__dirname, '..', '..');
+}
+
+function resolveDist(rootDir, distDir) {
+  if (!distDir) {
+    return path.join(rootDir, 'dist');
+  }
+
+  if (path.isAbsolute(distDir)) {
+    return distDir;
+  }
+
+  return path.join(rootDir, distDir);
+}
+
+async function ensureDir(dirPath) {
+  await fs.mkdir(dirPath, { recursive: true });
+}
+
+async function readJson(filePath) {
+  const contents = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(contents);
+}
+
+async function readJsonSafe(filePath, fallback) {
+  try {
+    return await readJson(filePath);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return fallback;
+    }
+
+    throw error;
+  }
+}
+
+function toPosix(relativePath) {
+  return relativePath.split(path.sep).join('/');
+}
+
+function createLicenseBanner({ version, generatedAt, licenseData }) {
+  const project = licenseData?.project ?? {};
+  const dependencies = Array.isArray(licenseData?.dependencies) ? licenseData.dependencies : [];
+  const lines = [
+    'Win95Sim V2 release bundle',
+    `Version: ${version}`,
+    `Generated: ${generatedAt}`,
+  ];
+
+  if (project.name || project.license) {
+    lines.push('', `${project.name ?? 'Win95Sim V2'} — ${project.license ?? 'UNLICENSED'}`);
+  }
+
+  if (dependencies.length) {
+    lines.push('', 'Included dependencies:');
+    dependencies.forEach((dependency) => {
+      const label = dependency.name ?? 'unknown';
+      const license = dependency.license ?? 'UNLICENSED';
+      const homepage = dependency.homepage ? ` <${dependency.homepage}>` : '';
+      lines.push(`- ${label} (${license})${homepage}`);
+    });
+  }
+
+  return `<!--\n${lines.map((line) => ` ${line}`).join('\n')}\n-->`;
+}
+
+async function gatherAssetPayload(distDir, manifest) {
+  const styles = await Promise.all(
+    (manifest.styles ?? []).map(async (relativePath) => {
+      const absolutePath = path.join(distDir, relativePath);
+      const content = await fs.readFile(absolutePath, 'utf8');
+      return { path: toPosix(relativePath), content };
+    }),
+  );
+
+  let script;
+  if (manifest.script) {
+    const scriptPath = path.join(distDir, manifest.script);
+    const content = await fs.readFile(scriptPath, 'utf8');
+    script = { path: toPosix(manifest.script), content };
+  }
+
+  return { styles, script };
+}
+
+function renderReleaseHtml({ banner, styles, script }) {
+  const styleTags = styles
+    .map((style) => `    <style data-source="${style.path}">\n${style.content}\n    </style>`)
+    .join('\n');
+  const scriptTag = script
+    ? `    <script type="module" data-source="${script.path}">\n${script.content}\n    </script>`
+    : '';
+
+  return `${banner}\n<!doctype html>\n<html lang="en">\n  <head>\n    <meta charset="utf-8" />\n    <meta name="viewport" content="width=device-width, initial-scale=1" />\n    <meta name="generator" content="win95sim-v2 packager" />\n${styleTags}\n  </head>\n  <body>\n${scriptTag}\n  </body>\n</html>\n`;
+}
+
+async function computeFileMetadata(filePath, { relativeTo }) {
+  const buffer = await fs.readFile(filePath);
+  const sha256 = crypto.createHash('sha256').update(buffer).digest('hex');
+  const gzipSize = zlib.gzipSync(buffer).length;
+  const brotliSize = zlib.brotliCompressSync(buffer).length;
+  const relativePath = toPosix(path.relative(relativeTo, filePath));
+
+  return {
+    path: relativePath,
+    size: buffer.length,
+    sha256,
+    gzipSize,
+    brotliSize,
+  };
+}
+
+async function writeAboutData({ aboutPath, version, generatedAt, licenseData, manifest }) {
+  const licenses = [];
+  if (licenseData?.project) {
+    licenses.push({
+      name: licenseData.project.name ?? 'Win95Sim V2',
+      license: licenseData.project.license ?? 'UNLICENSED',
+      homepage: licenseData.project.homepage ?? null,
+    });
+  }
+
+  if (Array.isArray(licenseData?.dependencies)) {
+    licenseData.dependencies.forEach((dependency) => {
+      licenses.push({
+        name: dependency.name ?? 'unknown',
+        license: dependency.license ?? 'UNLICENSED',
+        homepage: dependency.homepage ?? null,
+      });
+    });
+  }
+
+  const aboutData = {
+    name: licenseData?.project?.name ?? 'Win95Sim V2',
+    version,
+    generatedAt,
+    manifest,
+    licenses,
+  };
+
+  await ensureDir(path.dirname(aboutPath));
+  await fs.writeFile(aboutPath, JSON.stringify(aboutData, null, 2));
+  return aboutData;
+}
+
+async function packageRelease(options = {}) {
+  const rootDir = resolveRoot(options.rootDir);
+  const distDir = resolveDist(rootDir, options.distDir);
+  const outputName = options.outputName ?? 'win95sim.html';
+  const manifestName = options.manifestName ?? 'manifest.json';
+  const licensePath = options.licensePath ?? path.join(rootDir, 'docs', 'licenses.json');
+  const packageJsonPath = options.packageJsonPath ?? path.join(rootDir, 'package.json');
+  const aboutDataPath = options.aboutDataPath ?? path.join(rootDir, 'src/apps/system/about/about.data.json');
+
+  if (!existsSync(distDir)) {
+    throw new Error(`Distribution directory not found: ${distDir}`);
+  }
+
+  const [licenseData, packageJson] = await Promise.all([
+    readJsonSafe(licensePath, {}),
+    readJsonSafe(packageJsonPath, {}),
+  ]);
+  const version = packageJson.version ?? '0.0.0';
+  const generatedAt = new Date().toISOString();
+
+  const sourceManifestPath = path.join(distDir, 'assets', 'manifest.json');
+  const sourceManifest = await readJsonSafe(sourceManifestPath, null);
+  if (!sourceManifest) {
+    throw new Error(`Expected build manifest at ${sourceManifestPath}`);
+  }
+
+  const assets = await gatherAssetPayload(distDir, sourceManifest);
+  const banner = createLicenseBanner({ version, generatedAt, licenseData });
+  const releaseHtml = renderReleaseHtml({ banner, styles: assets.styles, script: assets.script });
+  const releasePath = path.join(distDir, outputName);
+  await fs.writeFile(releasePath, releaseHtml, 'utf8');
+
+  const files = [await computeFileMetadata(releasePath, { relativeTo: distDir })];
+  const assetMetadata = [];
+  if (assets.script) {
+    assetMetadata.push(await computeFileMetadata(path.join(distDir, assets.script.path), { relativeTo: distDir }));
+  }
+  for (const style of assets.styles) {
+    assetMetadata.push(await computeFileMetadata(path.join(distDir, style.path), { relativeTo: distDir }));
+  }
+
+  const manifest = {
+    version,
+    generatedAt,
+    files,
+    assets: assetMetadata,
+    source: sourceManifest,
+  };
+
+  await fs.writeFile(path.join(distDir, manifestName), JSON.stringify(manifest, null, 2));
+  const aboutData = await writeAboutData({ aboutPath: aboutDataPath, version, generatedAt, licenseData, manifest });
+
+  return { manifest, aboutData, releasePath };
+}
+
+async function main() {
+  await packageRelease();
+  console.log('Release bundle generated.');
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  packageRelease,
+  createLicenseBanner,
+  computeFileMetadata,
+};


### PR DESCRIPTION
## Summary
- add a release packager that inlines build outputs, generates hashes, and writes release metadata
- introduce the diagnostics service with telemetry opt-in handling and expose it through the shell registry
- document the release workflow and add Phase 10 unit coverage for the packager and diagnostics service

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f65c6e4ec88329889a6bb793e039dc