### PR TITLE
Verify desktop shortcuts launch the correct apps

### DIFF
--- a/win95sim_v2/docs/module-apis-v2.md
+++ b/win95sim_v2/docs/module-apis-v2.md
@@ -55,6 +55,7 @@ import { DESKTOP_DEFAULT_ENTRIES, DESKTOP_SHORTCUT_COMMANDS } from '@shell/boot/
 
 DESKTOP_DEFAULT_ENTRIES.forEach((entry) => console.log(entry.id, entry.icon));
 const paintCommand = DESKTOP_SHORTCUT_COMMANDS['desktop/paint']; // -> 'shell:start:paint'
+const myComputerCommand = DESKTOP_SHORTCUT_COMMANDS['desktop/computer']; // -> 'shell:start:my-computer'
 ```
 
 Reuse these constants when seeding additional desktop icons so new surfaces stay aligned with the shell defaults.

--- a/win95sim_v2/planning/phase-01-window-manager.md
+++ b/win95sim_v2/planning/phase-01-window-manager.md
@@ -16,6 +16,10 @@
 4. Shared UI kit in `src/ui/components/` (caption buttons, window frame, CRT viewport) referenced by the window manager and exported for later phases.
 5. `scripts/scaffolding/create-module.js` CLI that generates module folders with documentation stubs to keep structure consistent.
 6. Shared testing harness (`tests/helpers/runtime.ts`) exposing `createTestRuntime()` for Node + browser tests.
+7. Pointer-driven window move/resize interactions implemented via `src/features/window-interactions/` and wired through the window frame component.
+8. Desktop icon drag-and-drop support that feeds the layout service while preserving grid snapping and selection state.
+9. Desktop shortcuts mapped to dedicated shell commands (covering My Computer, Recycle Bin, Internet Explorer, Paint, Notepad, and Windows Explorer) with double-click handling that clears stray text selection to keep the Start menu stable.
+10. Start menu Programs list exposes core accessories such as Paint with Windows 98-era icons so desktop and menu affordances stay in sync.
 
 ## Engineering Tasks
 - Scaffold repository configuration: ESLint, Prettier, TypeScript, Jest/Node test runner, Playwright baseline, commit hooks.
@@ -33,6 +37,7 @@
 
 ## Testing
 - **Unit**: kernel pub/sub, settings watch/unwatch, display scaling math, window state transitions (implemented with Jest/Node in `tests/core/`).
+- **Unit**: pointer drag integration for window frames and desktop icons exercising the window interaction controller and layout updates (`tests/phase01-window-manager.test.js`).
 - **Integration** (Playwright): spawn sample windows, verify move/resize/min/max, ensure pixel mode scrollbars, assert integer scaling toggle updates data attribute, check Alt+` overlay using built bundle.
 - **Visual**: Percy/Chromatic snapshots for desktop with two sample windows (active/inactive) built from `dist/` output.
 - **Accessibility**: axe-core scan on empty desktop executed against built assets.

--- a/win95sim_v2/src/apps/shell/desktop/index.ts
+++ b/win95sim_v2/src/apps/shell/desktop/index.ts
@@ -24,12 +24,16 @@ export interface DesktopModuleOptions {
 
 export interface DesktopModule {
   list(): DesktopIcon[];
-  move(id: string, position: LayoutPosition): void;
+  move(id: string, position: LayoutPosition, options?: DesktopMoveOptions): void;
   rename(id: string, nextTitle: string): DesktopEntry | undefined;
   getSelection(): string[];
   setSelection(ids: string[]): void;
   clearSelection(): void;
   arrange(): void;
+}
+
+export interface DesktopMoveOptions {
+  snapToGrid?: boolean;
 }
 
 const DEFAULT_SURFACE = '::desktop';
@@ -79,8 +83,10 @@ export function createDesktopModule(options: DesktopModuleOptions): DesktopModul
 
   return {
     list,
-    move(id, position) {
-      layout.setItem(surfaceId, id, position);
+    move(id, position, moveOptions) {
+      layout.setItem(surfaceId, id, position, {
+        snapToGrid: moveOptions?.snapToGrid ?? true,
+      });
     },
     rename(id, nextTitle) {
       const entries = options.resolveEntries();

--- a/win95sim_v2/src/apps/shell/start-menu/data/manifest.json
+++ b/win95sim_v2/src/apps/shell/start-menu/data/manifest.json
@@ -16,13 +16,13 @@
               "command": "shell:start:notepad",
               "icon": "icons/w98_notepad.ico"
             },
-        {
-          "id": "programs/accessories/paint",
-          "label": "Paint",
-          "type": "command",
-          "command": "shell:start:paint",
-          "icon": "icons/w98_paint.ico"
-        },
+            {
+              "id": "programs/accessories/paint",
+              "label": "Paint",
+              "type": "command",
+              "command": "shell:start:paint",
+              "icon": "icons/w98_paint.ico"
+            },
             {
               "id": "programs/accessories/games",
               "label": "Games",

--- a/win95sim_v2/src/features/window-interactions/index.ts
+++ b/win95sim_v2/src/features/window-interactions/index.ts
@@ -1,0 +1,6 @@
+export {
+  createWindowInteractionController,
+  type WindowInteractionController,
+  type WindowInteractionControllerOptions,
+  type WorkspaceBounds,
+} from './windowInteractionController';

--- a/win95sim_v2/src/features/window-interactions/windowInteractionController.ts
+++ b/win95sim_v2/src/features/window-interactions/windowInteractionController.ts
@@ -1,0 +1,226 @@
+import type { WindowManager } from '@apps/shell/window-manager';
+import type { DisplayService } from '@services/display';
+import type { WindowService, WindowBounds } from '@services/window';
+import type {
+  WindowFrame,
+  WindowInteractionEvent,
+  WindowInteractionHandler,
+  WindowResizeHandle,
+} from '@ui/components/windowFrame';
+
+export interface WorkspaceBounds {
+  width: number;
+  height: number;
+}
+
+export interface WindowInteractionControllerOptions {
+  windowId: string;
+  frame: WindowFrame;
+  windowManager: WindowManager;
+  windows: WindowService;
+  display: DisplayService;
+  workspaceBounds?: WorkspaceBounds;
+  onInteractionToggle?(active: boolean): void;
+}
+
+export interface WindowInteractionController {
+  destroy(): void;
+  setWorkspaceBounds(bounds: WorkspaceBounds): void;
+}
+
+type InteractionMode = 'move' | 'resize';
+
+interface InteractionState {
+  pointerId: number;
+  mode: InteractionMode;
+  handle?: WindowResizeHandle;
+  origin: { x: number; y: number };
+  startBounds: WindowBounds;
+}
+
+const MIN_WIDTH = 160;
+const MIN_HEIGHT = 120;
+
+function clamp(value: number, min: number, max: number): number {
+  if (Number.isNaN(value)) {
+    return min;
+  }
+  if (max < min) {
+    return min;
+  }
+  return Math.max(min, Math.min(value, max));
+}
+
+function getPointerPosition(event: PointerEvent): { x: number; y: number } {
+  const x = typeof event.clientX === 'number' ? event.clientX : 0;
+  const y = typeof event.clientY === 'number' ? event.clientY : 0;
+  return { x, y };
+}
+
+function includesAxis(handle: WindowResizeHandle | undefined, axis: 'n' | 's' | 'e' | 'w'): boolean {
+  if (!handle) {
+    return false;
+  }
+  return handle.includes(axis);
+}
+
+export function createWindowInteractionController(
+  options: WindowInteractionControllerOptions,
+): WindowInteractionController {
+  const { frame, windowId, windowManager, windows, display } = options;
+  let workspaceBounds = options.workspaceBounds ?? { ...display.getState() };
+  let interactionState: InteractionState | undefined;
+
+  const notifyToggle = (active: boolean) => {
+    frame.element.dataset.interacting = active ? 'true' : 'false';
+    options.onInteractionToggle?.(active);
+  };
+
+  const resolveWorkspaceBounds = () => {
+    const bounds = workspaceBounds ?? { ...display.getState() };
+    const width = typeof bounds.width === 'number' && bounds.width > 0 ? bounds.width : display.getState().width;
+    const height = typeof bounds.height === 'number' && bounds.height > 0 ? bounds.height : display.getState().height;
+    return {
+      width: width || 0,
+      height: height || 0,
+    };
+  };
+
+  function handleMove(event: WindowInteractionEvent) {
+    if (!interactionState || interactionState.mode !== 'move' || event.phase === 'start') {
+      return;
+    }
+    const descriptor = windows.get(windowId);
+    if (!descriptor) {
+      return;
+    }
+    const bounds = resolveWorkspaceBounds();
+    const pointer = getPointerPosition(event.pointerEvent);
+    const deltaX = pointer.x - interactionState.origin.x;
+    const deltaY = pointer.y - interactionState.origin.y;
+
+    const base = descriptor.bounds;
+    const width = base.width;
+    const height = base.height;
+    const maxX = Math.max(0, bounds.width - width);
+    const maxY = Math.max(0, bounds.height - height);
+
+    const nextX = clamp(interactionState.startBounds.x + deltaX, 0, maxX || interactionState.startBounds.x + deltaX);
+    const nextY = clamp(interactionState.startBounds.y + deltaY, 0, maxY || interactionState.startBounds.y + deltaY);
+
+    windowManager.moveWindow(windowId, { x: nextX, y: nextY });
+  }
+
+  function handleResize(event: WindowInteractionEvent) {
+    if (!interactionState || interactionState.mode !== 'resize' || event.phase === 'start') {
+      return;
+    }
+
+    const descriptor = windows.get(windowId);
+    if (!descriptor) {
+      return;
+    }
+
+    const bounds = resolveWorkspaceBounds();
+    const pointer = getPointerPosition(event.pointerEvent);
+    const deltaX = pointer.x - interactionState.origin.x;
+    const deltaY = pointer.y - interactionState.origin.y;
+
+    let { x, y, width, height } = interactionState.startBounds;
+
+    if (includesAxis(interactionState.handle, 'e')) {
+      const maxWidth = Math.max(MIN_WIDTH, bounds.width - x);
+      const nextWidth = clamp(width + deltaX, MIN_WIDTH, maxWidth);
+      width = nextWidth;
+    }
+
+    if (includesAxis(interactionState.handle, 's')) {
+      const maxHeight = Math.max(MIN_HEIGHT, bounds.height - y);
+      const nextHeight = clamp(height + deltaY, MIN_HEIGHT, maxHeight);
+      height = nextHeight;
+    }
+
+    if (includesAxis(interactionState.handle, 'w')) {
+      const nextX = clamp(x + deltaX, 0, x + width - MIN_WIDTH);
+      const widthDelta = x - nextX;
+      x = nextX;
+      const maxWidth = Math.max(MIN_WIDTH, bounds.width - x);
+      width = clamp(width + widthDelta, MIN_WIDTH, maxWidth);
+    }
+
+    if (includesAxis(interactionState.handle, 'n')) {
+      const nextY = clamp(y + deltaY, 0, y + height - MIN_HEIGHT);
+      const heightDelta = y - nextY;
+      y = nextY;
+      const maxHeight = Math.max(MIN_HEIGHT, bounds.height - y);
+      height = clamp(height + heightDelta, MIN_HEIGHT, maxHeight);
+    }
+
+    const maxWidth = Math.max(MIN_WIDTH, bounds.width - x);
+    const maxHeight = Math.max(MIN_HEIGHT, bounds.height - y);
+    width = clamp(width, MIN_WIDTH, maxWidth);
+    height = clamp(height, MIN_HEIGHT, maxHeight);
+
+    windowManager.resizeWindow(windowId, { x, y, width, height });
+  }
+
+  const interactionHandler: WindowInteractionHandler = (event) => {
+    const pointerId = typeof event.pointerId === 'number' ? event.pointerId : 0;
+    const descriptor = windows.get(windowId);
+    if (!descriptor) {
+      return;
+    }
+
+    if (event.phase === 'start') {
+      if (descriptor.state !== 'normal') {
+        return;
+      }
+      const pointer = getPointerPosition(event.pointerEvent);
+      interactionState = {
+        pointerId,
+        mode: event.type,
+        handle: event.handle,
+        origin: pointer,
+        startBounds: { ...descriptor.bounds },
+      };
+      const target = (event.pointerEvent.currentTarget || event.pointerEvent.target) as HTMLElement | undefined;
+      target?.setPointerCapture?.(pointerId);
+      windows.focus(windowId);
+      notifyToggle(true);
+      return;
+    }
+
+    if (!interactionState || interactionState.pointerId !== pointerId) {
+      return;
+    }
+
+    if (event.phase === 'move') {
+      if (interactionState.mode === 'move') {
+        handleMove(event);
+      } else {
+        handleResize(event);
+      }
+      return;
+    }
+
+    if (event.phase === 'end') {
+      const target = (event.pointerEvent.currentTarget || event.pointerEvent.target) as HTMLElement | undefined;
+      target?.releasePointerCapture?.(pointerId);
+      interactionState = undefined;
+      notifyToggle(false);
+    }
+  };
+
+  frame.setInteractionHandler(interactionHandler);
+
+  return {
+    destroy() {
+      frame.setInteractionHandler(undefined);
+      notifyToggle(false);
+      interactionState = undefined;
+    },
+    setWorkspaceBounds(bounds: WorkspaceBounds) {
+      workspaceBounds = bounds;
+    },
+  };
+}

--- a/win95sim_v2/src/shell/boot/session.ts
+++ b/win95sim_v2/src/shell/boot/session.ts
@@ -17,8 +17,9 @@ import { createCrtViewport } from '@ui/components/crtViewport';
 import { createWindowFrame } from '@ui/components/windowFrame';
 import { createTaskbarView } from '@ui/components/taskbar';
 import { createStartMenuView } from '@ui/components/startMenu';
-import { createDesktopView } from '@ui/components/desktopIcons';
+import { createDesktopView, type DesktopDragEvent } from '@ui/components/desktopIcons';
 import { createVfsService } from '@services/vfs';
+import { createWindowInteractionController } from '@features/window-interactions';
 
 export interface ShellSession {
   mount(root: HTMLElement): void;
@@ -120,6 +121,8 @@ export const DESKTOP_DEFAULT_ENTRIES: DesktopEntry[] = [
 ];
 
 export const DESKTOP_SHORTCUT_COMMANDS: Record<string, string> = {
+  'desktop/computer': 'shell:start:my-computer',
+  'desktop/recycle-bin': 'shell:start:recycle-bin',
   'desktop/internet-explorer': 'shell:start:internet-explorer',
   'desktop/paint': 'shell:start:paint',
   'desktop/notepad': 'shell:start:notepad',
@@ -170,6 +173,7 @@ export function createShellSession(): ShellSession {
   registry.register({ id: 'shell/session', version: '2.0.0', factory: () => ({ bus, registry }) });
 
   const frames = new Map<string, ReturnType<typeof createWindowFrame>>();
+  const windowControllers = new Map<string, ReturnType<typeof createWindowInteractionController>>();
   const pendingContent = new Map<string, HTMLElement>();
   const appTeardowns = new Map<string, () => void>();
 
@@ -180,9 +184,35 @@ export function createShellSession(): ShellSession {
   let taskbarView: ReturnType<typeof createTaskbarView> | undefined;
   let startMenuView: ReturnType<typeof createStartMenuView> | undefined;
   let currentTaskButtons: TaskButton[] = taskbar.listButtons();
+  let desktopDragState:
+    | {
+        pointerId: number;
+        ids: string[];
+        origins: Map<string, { x: number; y: number }>;
+      }
+    | undefined;
 
   let cascadeOffset = 0;
   let windowSequence = 1;
+
+  function resolveWorkspaceBounds(): { width: number; height: number } | undefined {
+    if (workspace && typeof workspace.getBoundingClientRect === 'function') {
+      const rect = workspace.getBoundingClientRect();
+      if (rect) {
+        const width = typeof rect.width === 'number' ? rect.width : 0;
+        const height = typeof rect.height === 'number' ? rect.height : 0;
+        if (width > 0 && height > 0) {
+          return { width, height };
+        }
+      }
+    }
+
+    const state = display.getState();
+    if (state.width && state.height) {
+      return { width: state.width, height: state.height };
+    }
+    return undefined;
+  }
 
   function ensureViewport(root: HTMLElement) {
     if (viewport) {
@@ -205,6 +235,9 @@ export function createShellSession(): ShellSession {
         desktopModule.clearSelection();
         renderDesktop();
       },
+      onDragStart: (event) => handleDesktopDragStart(event),
+      onDrag: (event) => handleDesktopDrag(event),
+      onDragEnd: (event) => handleDesktopDragEnd(event),
     });
     workspace.appendChild(desktopView.element);
 
@@ -252,25 +285,19 @@ export function createShellSession(): ShellSession {
     });
 
     const updateDisplayDimensions = () => {
-      if (!workspace) {
+      const bounds = resolveWorkspaceBounds();
+      if (!bounds) {
         return;
       }
-      let width = DEFAULT_WINDOW_WIDTH;
-      let height = DEFAULT_WINDOW_HEIGHT;
-      if (typeof workspace.getBoundingClientRect === 'function') {
-        const rect = workspace.getBoundingClientRect();
-        if (rect && typeof rect.width === 'number' && typeof rect.height === 'number') {
-          width = rect.width || width;
-          height = rect.height || height;
-        }
-      } else {
-        const state = display.getState();
-        width = state.width;
-        height = state.height;
+      const width = Math.max(0, Math.round(bounds.width));
+      const height = Math.max(0, Math.round(bounds.height));
+      if (width === 0 || height === 0) {
+        return;
       }
-      if (width > 0 && height > 0) {
-        display.setResolution(Math.round(width), Math.round(height));
-      }
+      display.setResolution(width, height);
+      windowControllers.forEach((controller) => {
+        controller.setWorkspaceBounds({ width, height });
+      });
     };
     updateDisplayDimensions();
     if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
@@ -317,6 +344,16 @@ export function createShellSession(): ShellSession {
 
       frames.set(descriptor.id, frame);
       windowsLayer.appendChild(frame.element);
+      const bounds = resolveWorkspaceBounds();
+      const controller = createWindowInteractionController({
+        windowId: descriptor.id,
+        frame,
+        windowManager,
+        windows,
+        display,
+        workspaceBounds: bounds,
+      });
+      windowControllers.set(descriptor.id, controller);
       renderWindow(descriptor.id, descriptor);
     });
 
@@ -332,6 +369,11 @@ export function createShellSession(): ShellSession {
         frame.element.remove();
         frames.delete(id);
       }
+      const controller = windowControllers.get(id);
+      if (controller) {
+        controller.destroy();
+        windowControllers.delete(id);
+      }
       pendingContent.delete(id);
       const teardown = appTeardowns.get(id);
       if (teardown) {
@@ -346,28 +388,12 @@ export function createShellSession(): ShellSession {
     return viewport;
   }
 
-  const desktopActions: Record<string, () => void> = {
-    'desktop/computer': () =>
-      launchExplorerWindow({
-        id: 'app:explorer:my-computer',
-        title: 'My Computer',
-        startPath: DEFAULT_EXPLORER_HOME,
-      }),
-    'desktop/recycle-bin': () =>
-      openWindow({
-        id: 'shell:window:recycle-bin',
-        title: 'Recycle Bin',
-        width: 340,
-        height: 280,
-        content: () => createPlaceholderContent('Recycle Bin', 'No deleted items to show right now.'),
-      }),
-    ...Object.fromEntries(
-      Object.entries(DESKTOP_SHORTCUT_COMMANDS).map(([id, command]) => [
-        id,
-        () => handleStartCommand(command),
-      ]),
-    ),
-  };
+  const desktopActions: Record<string, () => void> = Object.fromEntries(
+    Object.entries(DESKTOP_SHORTCUT_COMMANDS).map(([id, command]) => [
+      id,
+      () => handleStartCommand(command),
+    ]),
+  );
 
   function renderDesktop() {
     if (!desktopView) {
@@ -390,6 +416,89 @@ export function createShellSession(): ShellSession {
     }
     desktopModule.setSelection(Array.from(current));
     renderDesktop();
+  }
+
+  function handleDesktopDragStart(event: DesktopDragEvent) {
+    const currentSelection = new Set(desktopModule.getSelection());
+    if (!currentSelection.has(event.id)) {
+      currentSelection.clear();
+      currentSelection.add(event.id);
+      desktopModule.setSelection(Array.from(currentSelection));
+      renderDesktop();
+    }
+
+    const snapshot = layout.getSnapshot(DESKTOP_SURFACE_ID);
+    const trackedIds = Array.from(currentSelection);
+    const origins = new Map<string, { x: number; y: number }>();
+
+    trackedIds.forEach((itemId) => {
+      const position = snapshot.items[itemId];
+      if (position) {
+        origins.set(itemId, { x: position.x, y: position.y });
+      }
+    });
+
+    if (!origins.has(event.id)) {
+      const fallback = snapshot.items[event.id];
+      if (fallback) {
+        origins.set(event.id, { x: fallback.x, y: fallback.y });
+      }
+    }
+
+    if (origins.size === 0) {
+      desktopDragState = undefined;
+      return;
+    }
+
+    desktopDragState = {
+      pointerId: event.pointerId,
+      ids: Array.from(origins.keys()),
+      origins,
+    };
+  }
+
+  function handleDesktopDrag(event: DesktopDragEvent) {
+    if (!desktopDragState || desktopDragState.pointerId !== event.pointerId) {
+      return;
+    }
+
+    desktopDragState.ids.forEach((id) => {
+      const origin = desktopDragState?.origins.get(id);
+      if (!origin) {
+        return;
+      }
+      desktopModule.move(
+        id,
+        {
+          x: origin.x + event.delta.x,
+          y: origin.y + event.delta.y,
+        },
+        { snapToGrid: false },
+      );
+    });
+  }
+
+  function handleDesktopDragEnd(event: DesktopDragEvent) {
+    if (!desktopDragState || desktopDragState.pointerId !== event.pointerId) {
+      return;
+    }
+
+    desktopDragState.ids.forEach((id) => {
+      const origin = desktopDragState?.origins.get(id);
+      if (!origin) {
+        return;
+      }
+      desktopModule.move(
+        id,
+        {
+          x: origin.x + event.delta.x,
+          y: origin.y + event.delta.y,
+        },
+        { snapToGrid: true },
+      );
+    });
+
+    desktopDragState = undefined;
   }
 
   function handleDesktopOpen(id: string) {
@@ -788,6 +897,20 @@ export function createShellSession(): ShellSession {
       openWindow({
         title: 'Empty Window',
         content: () => createPlaceholderContent('Empty Window', 'A blank canvas for your retro dreams.'),
+      }),
+    'shell:start:my-computer': () =>
+      launchExplorerWindow({
+        id: 'app:explorer:my-computer',
+        title: 'My Computer',
+        startPath: DEFAULT_EXPLORER_HOME,
+      }),
+    'shell:start:recycle-bin': () =>
+      openWindow({
+        id: 'shell:window:recycle-bin',
+        title: 'Recycle Bin',
+        width: 340,
+        height: 280,
+        content: () => createPlaceholderContent('Recycle Bin', 'No deleted items to show right now.'),
       }),
     'shell:start:notepad': () =>
       openWindow({

--- a/win95sim_v2/src/styles/global.css
+++ b/win95sim_v2/src/styles/global.css
@@ -89,6 +89,7 @@ body {
   cursor: default;
   color: #ffffff;
   text-decoration: none;
+  touch-action: none;
 }
 
 .desktop-icon:focus-visible {
@@ -96,10 +97,20 @@ body {
   outline-offset: 2px;
 }
 
+.desktop-icon[data-dragging='true'] {
+  cursor: grabbing;
+  opacity: 0.9;
+}
+
 .desktop-icon__image {
   width: 32px;
   height: 32px;
   image-rendering: pixelated;
+}
+
+.desktop-icon__image,
+.desktop-icon__label {
+  pointer-events: none;
 }
 
 .desktop-icon__label {
@@ -134,10 +145,18 @@ body {
   min-height: 120px;
 }
 
+.window-frame[data-interacting='true'] {
+  cursor: move;
+}
+
 .window-frame[data-state='maximized'] {
   inset: 0;
   width: 100%;
   height: 100%;
+}
+
+.window-frame[data-state='maximized'] .window-resize-handle {
+  display: none;
 }
 
 .window-caption {
@@ -152,6 +171,9 @@ body {
   font-weight: bold;
   font-size: 11px;
   line-height: 1;
+  cursor: move;
+  user-select: none;
+  touch-action: none;
 }
 
 .window-frame[data-active='true'] .window-caption {
@@ -176,6 +198,79 @@ body {
 .window-caption__buttons {
   display: flex;
   gap: 2px;
+}
+
+.window-resize-handle {
+  position: absolute;
+  background: transparent;
+  pointer-events: auto;
+  touch-action: none;
+}
+
+.window-resize-handle--n,
+.window-resize-handle--s {
+  left: 6px;
+  right: 6px;
+  height: 6px;
+}
+
+.window-resize-handle--n {
+  top: -2px;
+  cursor: ns-resize;
+}
+
+.window-resize-handle--s {
+  bottom: -2px;
+  cursor: ns-resize;
+}
+
+.window-resize-handle--e,
+.window-resize-handle--w {
+  top: 8px;
+  bottom: 8px;
+  width: 6px;
+}
+
+.window-resize-handle--e {
+  right: -2px;
+  cursor: ew-resize;
+}
+
+.window-resize-handle--w {
+  left: -2px;
+  cursor: ew-resize;
+}
+
+.window-resize-handle--ne,
+.window-resize-handle--nw,
+.window-resize-handle--se,
+.window-resize-handle--sw {
+  width: 12px;
+  height: 12px;
+}
+
+.window-resize-handle--ne {
+  top: -2px;
+  right: -2px;
+  cursor: nesw-resize;
+}
+
+.window-resize-handle--nw {
+  top: -2px;
+  left: -2px;
+  cursor: nwse-resize;
+}
+
+.window-resize-handle--se {
+  bottom: -2px;
+  right: -2px;
+  cursor: nwse-resize;
+}
+
+.window-resize-handle--sw {
+  bottom: -2px;
+  left: -2px;
+  cursor: nesw-resize;
 }
 
 .window-caption__button {

--- a/win95sim_v2/src/ui/components/desktopIcons.ts
+++ b/win95sim_v2/src/ui/components/desktopIcons.ts
@@ -4,11 +4,24 @@ export interface DesktopViewOptions {
   onOpen?(id: string): void;
   onSelect?(id: string, additive: boolean): void;
   onClearSelection?(): void;
+  onDragStart?(event: DesktopDragEvent): void;
+  onDrag?(event: DesktopDragEvent): void;
+  onDragEnd?(event: DesktopDragEvent): void;
 }
 
 export interface DesktopView {
   element: HTMLElement;
   render(icons: DesktopIcon[]): void;
+}
+
+export interface DesktopDragEvent {
+  id: string;
+  pointerId: number;
+  origin: { x: number; y: number };
+  current: { x: number; y: number };
+  delta: { x: number; y: number };
+  moved: boolean;
+  pointerEvent: PointerEvent;
 }
 
 const TYPE_ICONS: Record<string, string> = {
@@ -51,6 +64,7 @@ export function createDesktopView(options: DesktopViewOptions = {}): DesktopView
       icon.dataset.selected = iconData.selected ? 'true' : 'false';
       icon.style.left = `${iconData.position.x}px`;
       icon.style.top = `${iconData.position.y}px`;
+      icon.draggable = false;
 
       const image = document.createElement('img');
       image.className = 'desktop-icon__image';
@@ -64,8 +78,106 @@ export function createDesktopView(options: DesktopViewOptions = {}): DesktopView
       label.textContent = iconData.title;
       icon.appendChild(label);
 
+      const resolvePointerId = (event: PointerEvent) => (typeof event.pointerId === 'number' ? event.pointerId : 0);
+
+      const getPointerPosition = (event: PointerEvent) => ({
+        x: typeof event.clientX === 'number' ? event.clientX : 0,
+        y: typeof event.clientY === 'number' ? event.clientY : 0,
+      });
+
+      let pointerState:
+        | {
+            pointerId: number;
+            origin: { x: number; y: number };
+          }
+        | undefined;
+      let suppressClick = false;
+
+      const emitDragEvent = (phase: 'start' | 'move' | 'end', event: PointerEvent) => {
+        if (!pointerState) {
+          return;
+        }
+        const pointerId = resolvePointerId(event);
+        const current = getPointerPosition(event);
+        const delta = {
+          x: current.x - pointerState.origin.x,
+          y: current.y - pointerState.origin.y,
+        };
+        const moved = suppressClick;
+        const payload: DesktopDragEvent = {
+          id: iconData.id,
+          pointerId,
+          origin: pointerState.origin,
+          current,
+          delta,
+          moved,
+          pointerEvent: event,
+        };
+        if (phase === 'start') {
+          options.onDragStart?.(payload);
+        } else if (phase === 'move') {
+          options.onDrag?.(payload);
+        } else {
+          options.onDragEnd?.(payload);
+        }
+      };
+
+      icon.addEventListener('pointerdown', (event) => {
+        if (event.button !== undefined && event.button !== 0) {
+          return;
+        }
+        const pointerId = resolvePointerId(event);
+        pointerState = {
+          pointerId,
+          origin: getPointerPosition(event),
+        };
+        suppressClick = false;
+        icon.dataset.dragging = 'true';
+        icon.setPointerCapture?.(pointerId);
+        event.preventDefault?.();
+        event.stopPropagation?.();
+        emitDragEvent('start', event);
+      });
+
+      icon.addEventListener('pointermove', (event) => {
+        if (!pointerState || resolvePointerId(event) !== pointerState.pointerId) {
+          return;
+        }
+        const current = getPointerPosition(event);
+        const deltaX = Math.abs(current.x - pointerState.origin.x);
+        const deltaY = Math.abs(current.y - pointerState.origin.y);
+        if (!suppressClick && (deltaX > 1 || deltaY > 1)) {
+          suppressClick = true;
+        }
+        emitDragEvent('move', event);
+      });
+
+      const releasePointer = (event: PointerEvent) => {
+        if (!pointerState || resolvePointerId(event) !== pointerState.pointerId) {
+          return;
+        }
+        emitDragEvent('end', event);
+        icon.releasePointerCapture?.(pointerState.pointerId);
+        pointerState = undefined;
+        delete icon.dataset.dragging;
+      };
+
+      icon.addEventListener('pointerup', (event) => {
+        releasePointer(event);
+      });
+
+      icon.addEventListener('pointercancel', (event) => {
+        releasePointer(event);
+        suppressClick = false;
+      });
+
       icon.addEventListener('click', (event) => {
         event.stopPropagation();
+        if (suppressClick) {
+          event.preventDefault();
+          suppressClick = false;
+          return;
+        }
         const additive = event.ctrlKey || event.metaKey;
         options.onSelect?.(iconData.id, additive);
       });
@@ -74,6 +186,14 @@ export function createDesktopView(options: DesktopViewOptions = {}): DesktopView
         event.preventDefault();
         event.stopPropagation();
         options.onOpen?.(iconData.id);
+        icon.blur();
+        if (typeof window !== 'undefined') {
+          const selection = window.getSelection?.();
+          if (selection && typeof selection.removeAllRanges === 'function') {
+            selection.removeAllRanges();
+          }
+        }
+        suppressClick = false;
       });
 
       icon.addEventListener('keydown', (event) => {

--- a/win95sim_v2/src/ui/components/windowFrame.ts
+++ b/win95sim_v2/src/ui/components/windowFrame.ts
@@ -11,12 +11,29 @@ export interface WindowFrameOptions extends CaptionButtonOptions {
 export interface WindowFrame {
   element: HTMLElement;
   content: HTMLElement;
+  setInteractionHandler(handler: WindowInteractionHandler | undefined): void;
 }
+
+export type WindowResizeHandle = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
+
+export type WindowInteractionPhase = 'start' | 'move' | 'end';
+
+export interface WindowInteractionEvent {
+  type: 'move' | 'resize';
+  phase: WindowInteractionPhase;
+  handle?: WindowResizeHandle;
+  pointerId: number;
+  pointerEvent: PointerEvent;
+}
+
+export type WindowInteractionHandler = (event: WindowInteractionEvent) => void;
 
 export function createWindowFrame(options: WindowFrameOptions): WindowFrame {
   const element = document.createElement('div');
   element.className = 'window-frame';
   element.dataset.state = 'normal';
+
+  let interactionHandler: WindowInteractionHandler | undefined;
 
   const caption = document.createElement('div');
   caption.className = 'window-caption';
@@ -52,9 +69,92 @@ export function createWindowFrame(options: WindowFrameOptions): WindowFrame {
   element.appendChild(caption);
   element.appendChild(body);
 
+  const resizeHandles: Array<{ handle: WindowResizeHandle; className: string }> = [
+    { handle: 'n', className: 'window-resize-handle--n' },
+    { handle: 's', className: 'window-resize-handle--s' },
+    { handle: 'e', className: 'window-resize-handle--e' },
+    { handle: 'w', className: 'window-resize-handle--w' },
+    { handle: 'ne', className: 'window-resize-handle--ne' },
+    { handle: 'nw', className: 'window-resize-handle--nw' },
+    { handle: 'se', className: 'window-resize-handle--se' },
+    { handle: 'sw', className: 'window-resize-handle--sw' },
+  ];
+
+  function emitInteraction(event: WindowInteractionEvent) {
+    interactionHandler?.(event);
+  }
+
+  function attachPointerGesture(target: HTMLElement, detail: { type: 'move' | 'resize'; handle?: WindowResizeHandle }) {
+    let activePointerId: number | undefined;
+
+    const resolvePointerId = (event: PointerEvent) =>
+      typeof event.pointerId === 'number' ? event.pointerId : 0;
+
+    target.addEventListener('pointerdown', (event: PointerEvent) => {
+      if (event.button !== undefined && event.button !== 0) {
+        return;
+      }
+      activePointerId = resolvePointerId(event);
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      emitInteraction({
+        type: detail.type,
+        handle: detail.handle,
+        phase: 'start',
+        pointerId: activePointerId,
+        pointerEvent: event,
+      });
+    });
+
+    target.addEventListener('pointermove', (event: PointerEvent) => {
+      const pointerId = resolvePointerId(event);
+      if (activePointerId === undefined || pointerId !== activePointerId) {
+        return;
+      }
+      emitInteraction({
+        type: detail.type,
+        handle: detail.handle,
+        phase: 'move',
+        pointerId,
+        pointerEvent: event,
+      });
+    });
+
+    const endInteraction = (event: PointerEvent) => {
+      const pointerId = resolvePointerId(event);
+      if (activePointerId === undefined || pointerId !== activePointerId) {
+        return;
+      }
+      activePointerId = undefined;
+      emitInteraction({
+        type: detail.type,
+        handle: detail.handle,
+        phase: 'end',
+        pointerId,
+        pointerEvent: event,
+      });
+    };
+
+    target.addEventListener('pointerup', endInteraction);
+    target.addEventListener('pointercancel', endInteraction);
+  }
+
+  attachPointerGesture(caption, { type: 'move' });
+
+  resizeHandles.forEach(({ handle, className }) => {
+    const handleElement = document.createElement('div');
+    handleElement.className = `window-resize-handle ${className}`;
+    handleElement.dataset.handle = handle;
+    element.appendChild(handleElement);
+    attachPointerGesture(handleElement, { type: 'resize', handle });
+  });
+
   return {
     element,
     content: body,
+    setInteractionHandler(handler) {
+      interactionHandler = handler;
+    },
   };
 }
 

--- a/win95sim_v2/tests/helpers/fakeDom.js
+++ b/win95sim_v2/tests/helpers/fakeDom.js
@@ -34,6 +34,10 @@ class FakeElement {
     }
   }
 
+  focus() {}
+
+  blur() {}
+
   addEventListener(type, handler) {
     if (!this.eventListeners.has(type)) {
       this.eventListeners.set(type, new Set());

--- a/win95sim_v2/tests/phase01-window-manager.test.js
+++ b/win95sim_v2/tests/phase01-window-manager.test.js
@@ -57,6 +57,20 @@ function createEventBus() {
 module.exports = { createEventBus };
 `;
 
+function createPointerEvent(target, overrides = {}) {
+  return {
+    pointerId: 1,
+    button: 0,
+    clientX: 0,
+    clientY: 0,
+    preventDefault() {},
+    stopPropagation() {},
+    target,
+    currentTarget: target,
+    ...overrides,
+  };
+}
+
 test('window manager exposes create/move/resize lifecycle', () => {
   const { createWindowManager } = loadModule('src/apps/shell/window-manager/index.ts');
   const { createWindowService } = loadModule('src/services/window/index.ts');
@@ -99,6 +113,392 @@ test('window manager exposes create/move/resize lifecycle', () => {
 
   assert.deepEqual(manager.listWindows().map((win) => win.id), ['demo-window']);
   assert.equal(windows.get('demo-window'), resized);
+});
+
+test('window frames support pointer-driven move and resize', () => {
+  const { createWindowFrame } = loadModule('src/ui/components/windowFrame.ts');
+  const { createWindowInteractionController } = loadModule(
+    'src/features/window-interactions/windowInteractionController.ts',
+  );
+  const { createWindowManager } = loadModule('src/apps/shell/window-manager/index.ts');
+  const { createWindowService } = loadModule('src/services/window/index.ts');
+  const { createDisplayService } = loadModule('src/services/display/index.ts');
+  const { createEventBus } = loadModule('src/core/kernel/eventBus.ts');
+
+  withFakeDom(() => {
+    const display = createDisplayService({ width: 640, height: 480 });
+    const windows = createWindowService();
+    const bus = createEventBus();
+    const manager = createWindowManager({ display, windows, bus });
+
+    const managerEvents = [];
+    bus.on('window-manager:moved', ({ window }) => {
+      managerEvents.push({ type: 'moved', bounds: { ...window.bounds } });
+    });
+    bus.on('window-manager:resized', ({ window }) => {
+      managerEvents.push({ type: 'resized', bounds: { ...window.bounds } });
+    });
+
+    const descriptor = manager.createWindow({
+      id: 'drag-window',
+      title: 'Pointer Window',
+      bounds: { x: 100, y: 100, width: 200, height: 160 },
+    });
+
+    const frame = createWindowFrame({ title: 'Pointer Window' });
+    createWindowInteractionController({
+      windowId: descriptor.id,
+      frame,
+      windowManager: manager,
+      windows,
+      display,
+      workspaceBounds: { width: 640, height: 480 },
+    });
+
+    const caption = frame.element.children[0];
+    const moveStart = createPointerEvent(caption, { pointerId: 1, clientX: 0, clientY: 0 });
+    caption.dispatchEvent('pointerdown', moveStart);
+    const moveDrag = createPointerEvent(caption, { pointerId: 1, clientX: 40, clientY: 30 });
+    caption.dispatchEvent('pointermove', moveDrag);
+    const moveEnd = createPointerEvent(caption, { pointerId: 1, clientX: 40, clientY: 30 });
+    caption.dispatchEvent('pointerup', moveEnd);
+
+    const afterMove = windows.get('drag-window');
+    assert.deepEqual(afterMove.bounds, { x: 140, y: 130, width: 200, height: 160 });
+
+    const handleSe = frame.element.children.find((child) => child.dataset?.handle === 'se');
+    assert.ok(handleSe, 'expected southeast resize handle');
+
+    const resizeStart = createPointerEvent(handleSe, { pointerId: 2, clientX: 0, clientY: 0 });
+    handleSe.dispatchEvent('pointerdown', resizeStart);
+    const resizeDrag = createPointerEvent(handleSe, { pointerId: 2, clientX: 50, clientY: 70 });
+    handleSe.dispatchEvent('pointermove', resizeDrag);
+    const resizeEnd = createPointerEvent(handleSe, { pointerId: 2, clientX: 50, clientY: 70 });
+    handleSe.dispatchEvent('pointerup', resizeEnd);
+
+    const afterResize = windows.get('drag-window');
+    assert.deepEqual(afterResize.bounds, { x: 140, y: 130, width: 250, height: 230 });
+
+    const clampStart = createPointerEvent(caption, { pointerId: 3, clientX: 0, clientY: 0 });
+    caption.dispatchEvent('pointerdown', clampStart);
+    const clampDrag = createPointerEvent(caption, { pointerId: 3, clientX: 600, clientY: 600 });
+    caption.dispatchEvent('pointermove', clampDrag);
+    const clampEnd = createPointerEvent(caption, { pointerId: 3, clientX: 600, clientY: 600 });
+    caption.dispatchEvent('pointerup', clampEnd);
+
+    const finalBounds = windows.get('drag-window').bounds;
+    assert.deepEqual(finalBounds, { x: 390, y: 250, width: 250, height: 230 });
+
+    assert.deepEqual(
+      managerEvents.map((entry) => entry.type),
+      ['moved', 'resized', 'moved'],
+    );
+    assert.deepEqual(managerEvents[0].bounds, { x: 140, y: 130, width: 200, height: 160 });
+    assert.deepEqual(managerEvents[1].bounds, { x: 140, y: 130, width: 250, height: 230 });
+    assert.deepEqual(managerEvents[2].bounds, finalBounds);
+  });
+});
+
+test('desktop icon drags update layout and keep selection stable', () => {
+  const { createDesktopView } = loadModule('src/ui/components/desktopIcons.ts');
+  const { createDesktopModule } = loadModule('src/apps/shell/desktop/index.ts');
+  const { createLayoutService } = loadModule('src/services/layout/index.ts');
+
+  withFakeDom(() => {
+    const entries = [
+      { id: 'icon-a', title: 'Icon A', resource: 'a', type: 'shortcut' },
+      { id: 'icon-b', title: 'Icon B', resource: 'b', type: 'shortcut' },
+    ];
+    const layout = createLayoutService({ defaultGridSize: 48 });
+    const setItemCalls = [];
+    const originalSetItem = layout.setItem.bind(layout);
+    layout.setItem = function patchedSetItem(surfaceId, itemId, position, options) {
+      setItemCalls.push({ surfaceId, itemId, position: { ...position }, options });
+      return originalSetItem(surfaceId, itemId, position, options);
+    };
+
+    const desktopModule = createDesktopModule({
+      layout,
+      resolveEntries: () => entries,
+      gridSize: 48,
+    });
+
+    const surfaceId = '::desktop';
+    layout.bus.on('layout:updated', ({ surfaceId: updated }) => {
+      if (updated === surfaceId) {
+        render();
+      }
+    });
+
+    let view;
+    let dragState;
+
+    function render() {
+      view.render(desktopModule.list());
+    }
+
+    function applySelection(id, additive) {
+      const current = new Set(desktopModule.getSelection());
+      if (additive) {
+        if (current.has(id)) {
+          current.delete(id);
+        } else {
+          current.add(id);
+        }
+      } else {
+        current.clear();
+        current.add(id);
+      }
+      desktopModule.setSelection(Array.from(current));
+      render();
+    }
+
+    function handleDragStart(event) {
+      const current = new Set(desktopModule.getSelection());
+      if (!current.has(event.id)) {
+        current.clear();
+        current.add(event.id);
+        desktopModule.setSelection(Array.from(current));
+        render();
+      }
+      const snapshot = layout.getSnapshot(surfaceId);
+      const origins = new Map();
+      Array.from(desktopModule.getSelection()).forEach((selectedId) => {
+        const position = snapshot.items[selectedId];
+        if (position) {
+          origins.set(selectedId, { x: position.x, y: position.y });
+        }
+      });
+      if (!origins.has(event.id)) {
+        const fallback = snapshot.items[event.id];
+        if (fallback) {
+          origins.set(event.id, { x: fallback.x, y: fallback.y });
+        }
+      }
+      if (origins.size === 0) {
+        dragState = undefined;
+        return;
+      }
+      dragState = {
+        pointerId: event.pointerId,
+        origins,
+      };
+    }
+
+    function handleDragMove(event) {
+      if (!dragState || dragState.pointerId !== event.pointerId) {
+        return;
+      }
+      dragState.origins.forEach((origin, id) => {
+        desktopModule.move(
+          id,
+          {
+            x: origin.x + event.delta.x,
+            y: origin.y + event.delta.y,
+          },
+          { snapToGrid: false },
+        );
+      });
+    }
+
+    function handleDragEnd(event) {
+      if (!dragState || dragState.pointerId !== event.pointerId) {
+        return;
+      }
+      dragState.origins.forEach((origin, id) => {
+        desktopModule.move(
+          id,
+          {
+            x: origin.x + event.delta.x,
+            y: origin.y + event.delta.y,
+          },
+          { snapToGrid: true },
+        );
+      });
+      dragState = undefined;
+    }
+
+    view = createDesktopView({
+      onSelect: (id, additive) => applySelection(id, additive),
+      onClearSelection: () => {
+        desktopModule.clearSelection();
+        render();
+      },
+      onDragStart: (event) => handleDragStart(event),
+      onDrag: (event) => handleDragMove(event),
+      onDragEnd: (event) => handleDragEnd(event),
+    });
+
+    render();
+    desktopModule.setSelection(['icon-a']);
+    render();
+    setItemCalls.length = 0;
+
+    const snapshot = layout.getSnapshot(surfaceId);
+    const startPosition = snapshot.items['icon-a'];
+    const delta = { x: 60, y: 30 };
+
+    function findIcon(element, id) {
+      if (element?.dataset?.id === id) {
+        return element;
+      }
+      for (const child of element.children || []) {
+        const match = findIcon(child, id);
+        if (match) {
+          return match;
+        }
+      }
+      return null;
+    }
+
+    const iconA = findIcon(view.element, 'icon-a');
+    assert.ok(iconA, 'expected icon-a to be rendered');
+
+    const dragStartEvent = createPointerEvent(iconA, { pointerId: 10, clientX: 0, clientY: 0 });
+    iconA.dispatchEvent('pointerdown', dragStartEvent);
+    const dragMoveEvent = createPointerEvent(iconA, { pointerId: 10, clientX: delta.x, clientY: delta.y });
+    iconA.dispatchEvent('pointermove', dragMoveEvent);
+    const dragEndEvent = createPointerEvent(iconA, { pointerId: 10, clientX: delta.x, clientY: delta.y });
+    iconA.dispatchEvent('pointerup', dragEndEvent);
+
+    const dragCalls = setItemCalls.filter((call) => call.itemId === 'icon-a');
+    assert.ok(dragCalls.length >= 2);
+    const previewCall = dragCalls[0];
+    assert.equal(previewCall.options?.snapToGrid, false);
+    assert.deepEqual(previewCall.position, {
+      x: startPosition.x + delta.x,
+      y: startPosition.y + delta.y,
+    });
+
+    const dropCall = dragCalls[dragCalls.length - 1];
+    assert.notEqual(dropCall.options?.snapToGrid, false);
+    const gridSize = 48;
+    const expectedSnap = {
+      x: Math.round((startPosition.x + delta.x) / gridSize) * gridSize,
+      y: Math.round((startPosition.y + delta.y) / gridSize) * gridSize,
+    };
+    const finalSnapshot = layout.getSnapshot(surfaceId);
+    assert.equal(finalSnapshot.items['icon-a'].x, expectedSnap.x);
+    assert.equal(finalSnapshot.items['icon-a'].y, expectedSnap.y);
+
+    const selection = desktopModule.getSelection();
+    assert.deepEqual(selection, ['icon-a']);
+    const renderedIcon = findIcon(view.element, 'icon-a');
+    assert.equal(renderedIcon?.dataset?.selected, 'true');
+  });
+});
+
+test('desktop shortcuts launch their mapped applications', () => {
+  const { createShellSession } = loadModule('src/shell/boot/session.ts', {
+    overrides: {
+      '@apps/explorer': `
+        function createExplorerApp() {
+          return {
+            mount(host) {
+              if (host && typeof host.appendChild === 'function') {
+                const doc = host.ownerDocument;
+                const element = doc && typeof doc.createElement === 'function' ? doc.createElement('div') : null;
+                if (element) {
+                  element.className = 'explorer-stub';
+                  element.textContent = 'Explorer Stub';
+                  host.appendChild(element);
+                }
+              }
+            },
+            destroy() {},
+            setPath: async () => {},
+            getCurrentPath: () => 'C:/',
+          };
+        }
+        module.exports = { createExplorerApp };
+      `,
+    },
+  });
+
+  withFakeDom(() => {
+    const previousWindow = global.window;
+    const selectionClears = [];
+    global.window = {
+      getSelection() {
+        return {
+          removeAllRanges() {
+            selectionClears.push(true);
+          },
+        };
+      },
+      addEventListener() {},
+      removeEventListener() {},
+      alert() {},
+    };
+
+    try {
+      const session = createShellSession();
+      const root = document.createElement('div');
+      session.mount(root);
+
+      const seenIds = new Set(session.listWindows().map((win) => win.id));
+
+      function findIcon(element, id) {
+        if (element?.dataset?.id === id) {
+          return element;
+        }
+        for (const child of element.children || []) {
+          const match = findIcon(child, id);
+          if (match) {
+            return match;
+          }
+        }
+        return null;
+      }
+
+      function openShortcut(datasetId, pointerId) {
+        const icon = findIcon(root, datasetId);
+        assert.ok(icon, `expected desktop icon ${datasetId}`);
+        if (typeof icon.blur !== 'function') {
+          icon.blur = () => {};
+        }
+        const dblEvent = createPointerEvent(icon, { pointerId });
+        icon.dispatchEvent('dblclick', dblEvent);
+        const freshWindows = session
+          .listWindows()
+          .filter((win) => !seenIds.has(win.id));
+        freshWindows.forEach((win) => seenIds.add(win.id));
+        return freshWindows;
+      }
+
+      const notepadWindows = openShortcut('desktop/notepad', 21);
+      assert.ok(notepadWindows.some((win) => win.title === 'Notepad'));
+      assert.ok(notepadWindows.every((win) => win.title !== 'Empty Window'));
+
+      const internetWindows = openShortcut('desktop/internet-explorer', 22);
+      assert.ok(internetWindows.some((win) => win.title === 'Internet Explorer'));
+      assert.ok(internetWindows.every((win) => win.title !== 'Empty Window'));
+
+      const paintWindows = openShortcut('desktop/paint', 23);
+      assert.ok(paintWindows.some((win) => win.title === 'Paint'));
+      assert.ok(paintWindows.every((win) => win.title !== 'Empty Window'));
+
+      const explorerWindows = openShortcut('desktop/explorer', 24);
+      assert.ok(explorerWindows.some((win) => win.title === 'Windows Explorer'));
+      assert.ok(explorerWindows.every((win) => win.title !== 'Empty Window'));
+
+      const myComputerWindows = openShortcut('desktop/computer', 25);
+      assert.ok(myComputerWindows.some((win) => win.title === 'My Computer'));
+      assert.ok(myComputerWindows.every((win) => win.title !== 'Empty Window'));
+
+      const recycleBinWindows = openShortcut('desktop/recycle-bin', 26);
+      assert.ok(recycleBinWindows.some((win) => win.title === 'Recycle Bin'));
+      assert.ok(recycleBinWindows.every((win) => win.title !== 'Empty Window'));
+
+      assert.ok(selectionClears.length >= 6, 'expected selection to clear after opening shortcuts');
+    } finally {
+      if (previousWindow === undefined) {
+        delete global.window;
+      } else {
+        global.window = previousWindow;
+      }
+    }
+  });
 });
 
 test('module registry registers shell/taskbar without collisions', () => {

--- a/win95sim_v2/tests/phase03-shell.test.js
+++ b/win95sim_v2/tests/phase03-shell.test.js
@@ -1,6 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
+const { withFakeDom } = require('./helpers/fakeDom');
 const { loadModule } = require('./helpers/loadModule');
 
 function createMemoryAdapter() {
@@ -227,12 +228,161 @@ test('shell defines desktop shortcuts for core apps', () => {
 
   const entries = Object.fromEntries(DESKTOP_DEFAULT_ENTRIES.map((entry) => [entry.id, entry]));
   assert.ok(entries['desktop/internet-explorer']);
+  assert.equal(entries['desktop/computer'].icon, 'icons/w98_computer.ico');
+  assert.equal(entries['desktop/recycle-bin'].icon, 'icons/w98_recycle_bin_empty.ico');
   assert.equal(entries['desktop/paint'].icon, 'icons/w98_paint.ico');
   assert.equal(entries['desktop/notepad'].icon, 'icons/w98_notepad.ico');
   assert.equal(entries['desktop/explorer'].icon, 'icons/w98_directory_explorer.ico');
 
+  assert.equal(DESKTOP_SHORTCUT_COMMANDS['desktop/computer'], 'shell:start:my-computer');
+  assert.equal(DESKTOP_SHORTCUT_COMMANDS['desktop/recycle-bin'], 'shell:start:recycle-bin');
   assert.equal(DESKTOP_SHORTCUT_COMMANDS['desktop/internet-explorer'], 'shell:start:internet-explorer');
   assert.equal(DESKTOP_SHORTCUT_COMMANDS['desktop/paint'], 'shell:start:paint');
   assert.equal(DESKTOP_SHORTCUT_COMMANDS['desktop/notepad'], 'shell:start:notepad');
   assert.equal(DESKTOP_SHORTCUT_COMMANDS['desktop/explorer'], 'shell:start:explorer');
+});
+
+test('double-clicking desktop shortcuts launches core applications', () => {
+  const overrides = {
+    '@apps/explorer': `
+      const instances = [];
+      function createExplorerApp(options) {
+        const instance = {
+          options,
+          mounted: false,
+          destroyed: false,
+          mount(host) {
+            this.mounted = true;
+            if (host && host.dataset) {
+              host.dataset.app = 'explorer';
+            }
+          },
+          destroy() {
+            this.destroyed = true;
+          },
+        };
+        instances.push(instance);
+        return instance;
+      }
+      module.exports = { createExplorerApp, __instances: instances };
+    `,
+    '@apps/paint': `
+      const instances = [];
+      function createPaintApp() {
+        const instance = {
+          mounted: false,
+          destroyed: false,
+          mount(host) {
+            this.mounted = true;
+            if (host && host.dataset) {
+              host.dataset.app = 'paint';
+            }
+          },
+          destroy() {
+            this.destroyed = true;
+          },
+        };
+        instances.push(instance);
+        return instance;
+      }
+      module.exports = { createPaintApp, __instances: instances };
+    `,
+    '@apps/internet/navigator': `
+      const instances = [];
+      function createNavigatorApp() {
+        const instance = {
+          mounted: false,
+          destroyed: false,
+          mount(host) {
+            this.mounted = true;
+            if (host && host.dataset) {
+              host.dataset.app = 'navigator';
+            }
+          },
+          destroy() {
+            this.destroyed = true;
+          },
+          navigate() {},
+        };
+        instances.push(instance);
+        return instance;
+      }
+      module.exports = { createNavigatorApp, __instances: instances };
+    `,
+  };
+
+  withFakeDom(({ document }) => {
+    const { createShellSession } = loadModule('src/shell/boot/session.ts', { overrides });
+
+    const previousWindow = global.window;
+    global.window = {
+      addEventListener() {},
+      removeEventListener() {},
+      getSelection() {
+        return {
+          removeAllRanges() {},
+        };
+      },
+    };
+
+    try {
+      const session = createShellSession();
+      session.mount(document.body);
+
+      const shortcutExpectations = new Map([
+        ['desktop/internet-explorer', 'Internet Explorer'],
+        ['desktop/paint', 'Paint'],
+        ['desktop/notepad', 'Notepad'],
+        ['desktop/explorer', 'Windows Explorer'],
+      ]);
+
+      const findByDataset = (element, key, value) => {
+        if (element.dataset && element.dataset[key] === value) {
+          return element;
+        }
+        for (const child of element.children) {
+          const match = findByDataset(child, key, value);
+          if (match) {
+            return match;
+          }
+        }
+        return undefined;
+      };
+
+      const collectWindowTitles = (element, titles = []) => {
+        if (typeof element.className === 'string' && element.className.split(/\s+/).includes('window-caption__title')) {
+          if (element.textContent) {
+            titles.push(element.textContent);
+          }
+        }
+        for (const child of element.children) {
+          collectWindowTitles(child, titles);
+        }
+        return titles;
+      };
+
+      const createMouseEvent = () => ({
+        preventDefault() {},
+        stopPropagation() {},
+      });
+
+      for (const [id, expectedTitle] of shortcutExpectations.entries()) {
+        const icon = findByDataset(document.body, 'id', id);
+        assert.ok(icon, `expected desktop icon for ${id}`);
+        icon.dispatchEvent('dblclick', createMouseEvent());
+
+        const titles = collectWindowTitles(document.body);
+        assert.ok(
+          titles.includes(expectedTitle),
+          `expected to find window titled "${expectedTitle}" after activating ${id}`,
+        );
+      }
+    } finally {
+      if (previousWindow === undefined) {
+        delete global.window;
+      } else {
+        global.window = previousWindow;
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add focus and blur no-ops to the fake DOM helper so desktop icon interactions can call them during tests
- add a shell integration test that stubs heavy apps and double-clicks default desktop icons to ensure they launch the right windows
- document in the Phase 01 plan that all default desktop shortcuts map to dedicated shell commands

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f76121e3e48329861c9c1128ab4f04