### PR TITLE
Prevent window dragging when caption buttons are clicked

### DIFF
--- a/win95sim_v2/src/ui/components/windowFrame.ts
+++ b/win95sim_v2/src/ui/components/windowFrame.ts
@@ -94,6 +94,11 @@ export function createWindowFrame(options: WindowFrameOptions): WindowFrame {
       if (event.button !== undefined && event.button !== 0) {
         return;
       }
+      if (detail.type === 'move' && event.target instanceof HTMLElement) {
+        if (event.target.closest('.window-caption__button')) {
+          return;
+        }
+      }
       activePointerId = resolvePointerId(event);
       event.preventDefault?.();
       event.stopPropagation?.();


### PR DESCRIPTION
## Summary
- update the window frame pointer gesture handler to ignore caption button clicks when initiating a drag
- ensure clicking minimize, maximize, or close triggers their handlers without starting a move interaction

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa898da3088329a143a859a9b1952a