### PR TITLE
Handle caption button detection without DOM globals

### DIFF
--- a/win95sim_v2/src/ui/components/windowFrame.ts
+++ b/win95sim_v2/src/ui/components/windowFrame.ts
@@ -28,6 +28,46 @@ export interface WindowInteractionEvent {
 
 export type WindowInteractionHandler = (event: WindowInteractionEvent) => void;
 
+function isCaptionButtonTarget(target: EventTarget | null): boolean {
+  if (!target || typeof target !== 'object') {
+    return false;
+  }
+
+  const element = target as {
+    classList?: { contains?: (className: string) => boolean };
+    className?: string;
+    parentElement?: EventTarget | null;
+    closest?: (selector: string) => Element | null;
+  };
+
+  if (typeof element.closest === 'function') {
+    const closestButton = element.closest('.window-caption__button');
+    if (closestButton) {
+      return true;
+    }
+  }
+
+  if (element.classList && typeof element.classList.contains === 'function') {
+    if (element.classList.contains('window-caption__button')) {
+      return true;
+    }
+  }
+
+  if (typeof element.className === 'string') {
+    const classNames = element.className.split(/\s+/);
+    if (classNames.includes('window-caption__button')) {
+      return true;
+    }
+  }
+
+  const parent = element.parentElement;
+  if (parent && parent !== target) {
+    return isCaptionButtonTarget(parent);
+  }
+
+  return false;
+}
+
 export function createWindowFrame(options: WindowFrameOptions): WindowFrame {
   const element = document.createElement('div');
   element.className = 'window-frame';
@@ -92,6 +132,9 @@ export function createWindowFrame(options: WindowFrameOptions): WindowFrame {
 
     target.addEventListener('pointerdown', (event: PointerEvent) => {
       if (event.button !== undefined && event.button !== 0) {
+        return;
+      }
+      if (detail.type === 'move' && isCaptionButtonTarget(event.target)) {
         return;
       }
       activePointerId = resolvePointerId(event);


### PR DESCRIPTION
## Summary
- add a helper that detects caption button targets without relying on DOM globals
- reuse the helper when starting move gestures so caption button clicks no longer trigger drags

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fa898da3088329a143a859a9b1952a