### PR TITLE
Refactor Minesweeper into dedicated module

### DIFF
--- a/win95sim_v2/README.md
+++ b/win95sim_v2/README.md
@@ -47,6 +47,7 @@ The current build ships working Win95 staples that double as reference integrati
 
 - **Internet Explorer** (`shell:start:internet-explorer`) – Navigator UI with toolbar, address bar, and sandboxed iframe viewport.
 - **Paint** (`shell:start:paint`) – Canvas-based paint studio backed by the Phase 06 engine and palette tooling.
+- **Minesweeper** (`shell:start:minesweeper`) – Classic grid puzzle powered by the shared game engine with difficulty presets.
 - **Notepad** (`shell:start:notepad`) – Phase 04 text editor with word wrap, font settings, and print integration.
 - **Windows Explorer** (`shell:start:explorer`) – VFS-driven file browser wired to the desktop layout service.
 

--- a/win95sim_v2/docs/utilities-extension-guide.md
+++ b/win95sim_v2/docs/utilities-extension-guide.md
@@ -35,7 +35,8 @@ apps to keep boundaries clean.
 
 For games, reuse helpers from `@services/games` for deterministic RNG and `@services/highScores`
 for session scoring. Minesweeper provides a reference implementation in
-`src/apps/games/minesweeper/` showing how to compose these services.
+`src/apps/games/minesweeper/` showing how to compose these services through the
+`createMinesweeperApp()` UI wrapper.
 
 ## 4. Testing expectations
 

--- a/win95sim_v2/src/apps/games/minesweeper/index.ts
+++ b/win95sim_v2/src/apps/games/minesweeper/index.ts
@@ -1,8 +1,468 @@
-export { createMinesweeperEngine } from './engine';
-export type {
-  MinesweeperEngine,
-  MinesweeperState,
+import { createMinesweeperEngine } from './engine';
+import type {
+  MinesweeperAppInstance,
+  MinesweeperAppOptions,
   MinesweeperCellState,
   MinesweeperConfig,
   MinesweeperDifficulty,
+  MinesweeperPreset,
+  MinesweeperState,
+} from './types';
+
+function clonePreset(preset: MinesweeperPreset): MinesweeperPreset {
+  return {
+    id: preset.id,
+    label: preset.label,
+    config: { ...preset.config },
+  };
+}
+
+function normalizePresetConfig(preset: MinesweeperPreset): MinesweeperConfig {
+  const config: MinesweeperConfig = { ...preset.config };
+  if (!config.difficulty) {
+    config.difficulty = preset.id;
+  }
+  if (config.firstClickSafe === undefined) {
+    config.firstClickSafe = true;
+  }
+  return config;
+}
+
+const DEFAULT_PRESETS: MinesweeperPreset[] = [
+  {
+    id: 'beginner',
+    label: 'Beginner (9×9, 10 mines)',
+    config: { width: 9, height: 9, mines: 10, difficulty: 'beginner', firstClickSafe: true },
+  },
+  {
+    id: 'intermediate',
+    label: 'Intermediate (16×16, 40 mines)',
+    config: { width: 16, height: 16, mines: 40, difficulty: 'intermediate', firstClickSafe: true },
+  },
+  {
+    id: 'expert',
+    label: 'Expert (30×16, 99 mines)',
+    config: { width: 30, height: 16, mines: 99, difficulty: 'expert', firstClickSafe: true },
+  },
+];
+
+function formatCount(value: number): string {
+  const clamped = Math.max(-999, Math.min(999, value));
+  const prefix = clamped < 0 ? '-' : '';
+  const absolute = Math.abs(clamped).toString().padStart(3, '0');
+  return `${prefix}${absolute}`;
+}
+
+export function createMinesweeperApp(options: MinesweeperAppOptions = {}): MinesweeperAppInstance {
+  const presetList = (options.presets && options.presets.length > 0 ? options.presets : DEFAULT_PRESETS).map(clonePreset);
+  if (presetList.length === 0) {
+    throw new Error('Minesweeper requires at least one difficulty preset.');
+  }
+
+  const engineFactory = options.engineFactory ?? ((config: MinesweeperConfig) => createMinesweeperEngine(config));
+
+  const resolvePreset = (difficulty?: MinesweeperDifficulty): MinesweeperPreset | undefined =>
+    difficulty ? presetList.find((preset) => preset.id === difficulty) : undefined;
+
+  let activePreset = resolvePreset(options.difficulty) ?? presetList[0];
+  let engine = engineFactory(normalizePresetConfig(activePreset));
+  let currentState: MinesweeperState = engine.getState();
+
+  let host: HTMLElement | null = null;
+  let container: HTMLElement | null = null;
+  let toolbar: HTMLDivElement | null = null;
+  let controls: HTMLDivElement | null = null;
+  let difficultySelect: HTMLSelectElement | null = null;
+  let newGameButton: HTMLButtonElement | null = null;
+  let statusPanel: HTMLDivElement | null = null;
+  let minesCounter: HTMLSpanElement | null = null;
+  let statusIndicator: HTMLSpanElement | null = null;
+  let timerCounter: HTMLSpanElement | null = null;
+  let boardWrapper: HTMLDivElement | null = null;
+  let boardElement: HTMLDivElement | null = null;
+
+  let timerHandle: ReturnType<typeof setInterval> | undefined;
+  let timerStartedAt: number | null = null;
+  let elapsedSeconds = 0;
+
+  const cleanupListeners: Array<() => void> = [];
+
+  function updateTimerDisplay() {
+    if (!timerCounter) {
+      return;
+    }
+    timerCounter.textContent = formatCount(elapsedSeconds);
+    timerCounter.setAttribute('aria-label', `Elapsed time: ${elapsedSeconds} seconds`);
+  }
+
+  function pauseTimer() {
+    if (timerHandle !== undefined) {
+      clearInterval(timerHandle);
+      timerHandle = undefined;
+    }
+    if (timerStartedAt !== null) {
+      elapsedSeconds = Math.floor((Date.now() - timerStartedAt) / 1000);
+      timerStartedAt = null;
+    }
+    updateTimerDisplay();
+  }
+
+  function ensureTimerRunning() {
+    if (timerHandle !== undefined) {
+      return;
+    }
+    if (timerStartedAt === null) {
+      timerStartedAt = Date.now() - elapsedSeconds * 1000;
+    }
+    timerHandle = setInterval(() => {
+      if (timerStartedAt !== null) {
+        elapsedSeconds = Math.floor((Date.now() - timerStartedAt) / 1000);
+        updateTimerDisplay();
+      }
+    }, 1000);
+    updateTimerDisplay();
+  }
+
+  function resetTimer() {
+    pauseTimer();
+    elapsedSeconds = 0;
+    updateTimerDisplay();
+  }
+
+  function applyCellClasses(button: HTMLButtonElement, cell: MinesweeperCellState, state: MinesweeperState) {
+    const classes = ['app-minesweeper__cell'];
+    const revealMine = cell.hasMine && (cell.isRevealed || (state.status === 'lost' && !cell.isFlagged));
+    const isRevealed = cell.isRevealed || revealMine;
+
+    if (isRevealed) {
+      classes.push('app-minesweeper__cell--revealed');
+    }
+
+    if (cell.isFlagged) {
+      classes.push('app-minesweeper__cell--flagged');
+      if (state.status === 'lost' && !cell.hasMine) {
+        classes.push('app-minesweeper__cell--incorrect');
+      }
+    } else if (revealMine) {
+      classes.push('app-minesweeper__cell--mine');
+    } else if (cell.isRevealed && cell.adjacentMines > 0) {
+      classes.push(`app-minesweeper__cell--number-${cell.adjacentMines}`);
+    }
+
+    button.className = classes.join(' ');
+  }
+
+  function renderBoard(state: MinesweeperState) {
+    if (!boardElement) {
+      return;
+    }
+
+    boardElement.innerHTML = '';
+    boardElement.style.gridTemplateColumns = `repeat(${state.width}, 24px)`;
+    boardElement.setAttribute('aria-rowcount', state.height.toString());
+    boardElement.setAttribute('aria-colcount', state.width.toString());
+    boardElement.setAttribute('data-status', state.status);
+
+    state.board.forEach((row) => {
+      row.forEach((cell) => {
+        const cellButton = document.createElement('button') as HTMLButtonElement;
+        cellButton.type = 'button';
+        cellButton.dataset.x = cell.x.toString();
+        cellButton.dataset.y = cell.y.toString();
+        cellButton.setAttribute('role', 'gridcell');
+
+        applyCellClasses(cellButton, cell, state);
+
+        if (cell.isFlagged) {
+          if (state.status === 'lost' && !cell.hasMine) {
+            cellButton.textContent = '✖';
+            cellButton.setAttribute('aria-label', 'Incorrect flag');
+          } else {
+            cellButton.textContent = '⚑';
+            cellButton.setAttribute('aria-label', 'Flagged cell');
+          }
+        } else if (cell.hasMine && (cell.isRevealed || state.status === 'lost')) {
+          cellButton.textContent = '💣';
+          cellButton.setAttribute('aria-label', 'Mine');
+        } else if (cell.isRevealed) {
+          const count = cell.adjacentMines;
+          if (count > 0) {
+            cellButton.textContent = String(count);
+            cellButton.setAttribute('aria-label', `${count} adjacent mines`);
+          } else {
+            cellButton.textContent = '';
+            cellButton.setAttribute('aria-label', 'Empty cell');
+          }
+        } else {
+          cellButton.textContent = '';
+          cellButton.setAttribute('aria-label', 'Hidden cell');
+        }
+
+        cellButton.disabled = cell.isRevealed && !cell.hasMine;
+        boardElement.appendChild(cellButton);
+      });
+    });
+  }
+
+  function updateStatus(state: MinesweeperState) {
+    if (!minesCounter || !statusIndicator) {
+      return;
+    }
+
+    const remainingMines = state.mines - state.flags;
+    minesCounter.textContent = formatCount(remainingMines);
+    minesCounter.setAttribute('aria-label', `Mines remaining: ${remainingMines}`);
+
+    const statusFaces: Record<MinesweeperState['status'], string> = {
+      ready: '🙂 Ready',
+      'in-progress': '😮 In progress',
+      won: '😎 You win!',
+      lost: '😵 Boom!',
+    };
+
+    statusIndicator.textContent = statusFaces[state.status];
+    statusIndicator.dataset.state = state.status;
+    statusIndicator.setAttribute('aria-label', statusFaces[state.status]);
+
+    switch (state.status) {
+      case 'ready':
+        pauseTimer();
+        break;
+      case 'in-progress':
+        ensureTimerRunning();
+        break;
+      case 'won':
+      case 'lost':
+        pauseTimer();
+        break;
+      default:
+        pauseTimer();
+        break;
+    }
+  }
+
+  function render(state: MinesweeperState) {
+    if (difficultySelect) {
+      const presetExists = presetList.some((preset) => preset.id === state.difficulty);
+      difficultySelect.value = presetExists ? state.difficulty : activePreset.id;
+    }
+
+    updateStatus(state);
+    renderBoard(state);
+    updateTimerDisplay();
+  }
+
+  function updateState(next: MinesweeperState) {
+    currentState = next;
+    render(currentState);
+  }
+
+  function selectPreset(difficulty: MinesweeperDifficulty) {
+    const preset = resolvePreset(difficulty) ?? presetList[0];
+    activePreset = preset;
+    engine = engineFactory(normalizePresetConfig(preset));
+    currentState = engine.getState();
+    resetTimer();
+    render(currentState);
+  }
+
+  function generateSeed() {
+    return Math.random().toString(36).slice(2, 10);
+  }
+
+  const handleCellClick = (event: MouseEvent) => {
+    const target = event.target as HTMLElement | null;
+    const cellElement = target?.closest('.app-minesweeper__cell') as HTMLButtonElement | null;
+    if (!cellElement) {
+      return;
+    }
+    const x = Number(cellElement.dataset.x);
+    const y = Number(cellElement.dataset.y);
+    if (Number.isNaN(x) || Number.isNaN(y)) {
+      return;
+    }
+    const nextState = engine.reveal(x, y);
+    updateState(nextState);
+  };
+
+  const handleContextMenu = (event: MouseEvent) => {
+    const target = event.target as HTMLElement | null;
+    const cellElement = target?.closest('.app-minesweeper__cell') as HTMLButtonElement | null;
+    if (!cellElement) {
+      return;
+    }
+    event.preventDefault();
+    const x = Number(cellElement.dataset.x);
+    const y = Number(cellElement.dataset.y);
+    if (Number.isNaN(x) || Number.isNaN(y)) {
+      return;
+    }
+    const nextState = engine.toggleFlag(x, y);
+    updateState(nextState);
+  };
+
+  const handleNewGame = () => {
+    const nextState = engine.reset(generateSeed());
+    resetTimer();
+    updateState(nextState);
+  };
+
+  const handleDifficultyChange = () => {
+    if (!difficultySelect) {
+      return;
+    }
+    const value = difficultySelect.value as MinesweeperDifficulty;
+    selectPreset(value);
+  };
+
+  function clearHost() {
+    if (host && container && container.parentElement === host) {
+      host.removeChild(container);
+    } else {
+      container?.remove();
+    }
+  }
+
+  function mount(target: HTMLElement) {
+    if (!target) {
+      throw new Error('A host element is required to mount the Minesweeper app.');
+    }
+
+    destroy();
+
+    host = target;
+    container = document.createElement('div');
+    container.className = 'app-minesweeper';
+
+    toolbar = document.createElement('div');
+    toolbar.className = 'app-minesweeper__toolbar';
+    container.appendChild(toolbar);
+
+    controls = document.createElement('div');
+    controls.className = 'app-minesweeper__controls';
+    toolbar.appendChild(controls);
+
+    const difficultyLabel = document.createElement('label');
+    difficultyLabel.className = 'app-minesweeper__label';
+    difficultyLabel.textContent = 'Difficulty:';
+
+    difficultySelect = document.createElement('select');
+    difficultySelect.className = 'app-minesweeper__select';
+    presetList.forEach((preset) => {
+      const option = document.createElement('option');
+      option.value = preset.id;
+      option.textContent = preset.label;
+      difficultySelect?.appendChild(option);
+    });
+    if (difficultySelect) {
+      difficultySelect.value = activePreset.id;
+      difficultyLabel.appendChild(difficultySelect);
+    }
+
+    newGameButton = document.createElement('button');
+    newGameButton.type = 'button';
+    newGameButton.className = 'app-minesweeper__button';
+    newGameButton.textContent = 'New Game';
+
+    controls.appendChild(difficultyLabel);
+    controls.appendChild(newGameButton);
+
+    statusPanel = document.createElement('div');
+    statusPanel.className = 'app-minesweeper__status';
+
+    minesCounter = document.createElement('span');
+    minesCounter.className = 'app-minesweeper__counter';
+    minesCounter.setAttribute('aria-live', 'polite');
+    statusPanel.appendChild(minesCounter);
+
+    statusIndicator = document.createElement('span');
+    statusIndicator.className = 'app-minesweeper__indicator';
+    statusIndicator.setAttribute('role', 'status');
+    statusIndicator.setAttribute('aria-live', 'polite');
+    statusPanel.appendChild(statusIndicator);
+
+    timerCounter = document.createElement('span');
+    timerCounter.className = 'app-minesweeper__counter';
+    timerCounter.setAttribute('aria-live', 'polite');
+    statusPanel.appendChild(timerCounter);
+
+    toolbar.appendChild(statusPanel);
+
+    boardWrapper = document.createElement('div');
+    boardWrapper.className = 'app-minesweeper__board-wrapper';
+
+    boardElement = document.createElement('div');
+    boardElement.className = 'app-minesweeper__board';
+    boardElement.setAttribute('role', 'grid');
+    boardElement.setAttribute('aria-label', 'Minesweeper board');
+    boardWrapper.appendChild(boardElement);
+
+    container.appendChild(boardWrapper);
+
+    difficultySelect?.addEventListener('change', handleDifficultyChange);
+    cleanupListeners.push(() => difficultySelect?.removeEventListener('change', handleDifficultyChange));
+
+    newGameButton.addEventListener('click', handleNewGame);
+    cleanupListeners.push(() => newGameButton?.removeEventListener('click', handleNewGame));
+
+    boardElement.addEventListener('click', handleCellClick);
+    cleanupListeners.push(() => boardElement?.removeEventListener('click', handleCellClick));
+
+    boardElement.addEventListener('contextmenu', handleContextMenu);
+    cleanupListeners.push(() => boardElement?.removeEventListener('contextmenu', handleContextMenu));
+
+    host.appendChild(container);
+
+    resetTimer();
+    render(currentState);
+  }
+
+  function destroy() {
+    pauseTimer();
+    cleanupListeners.splice(0).forEach((cleanup) => {
+      try {
+        cleanup();
+      } catch {
+        // Ignore listener cleanup issues in non-DOM test environments.
+      }
+    });
+
+    clearHost();
+
+    host = null;
+    container = null;
+    toolbar = null;
+    controls = null;
+    difficultySelect = null;
+    newGameButton = null;
+    statusPanel = null;
+    minesCounter = null;
+    statusIndicator = null;
+    timerCounter = null;
+    boardWrapper = null;
+    boardElement = null;
+  }
+
+  return {
+    mount,
+    destroy,
+    setDifficulty(difficulty: MinesweeperDifficulty) {
+      selectPreset(difficulty);
+    },
+    getState() {
+      return currentState;
+    },
+  };
+}
+
+export { createMinesweeperEngine } from './engine';
+export type {
+  MinesweeperAppInstance,
+  MinesweeperAppOptions,
+  MinesweeperCellState,
+  MinesweeperConfig,
+  MinesweeperDifficulty,
+  MinesweeperEngine,
+  MinesweeperPreset,
+  MinesweeperState,
 } from './types';

--- a/win95sim_v2/src/apps/games/minesweeper/types.ts
+++ b/win95sim_v2/src/apps/games/minesweeper/types.ts
@@ -35,3 +35,22 @@ export interface MinesweeperEngine {
   toggleFlag(x: number, y: number): MinesweeperState;
   reset(seed?: string): MinesweeperState;
 }
+
+export interface MinesweeperPreset {
+  id: MinesweeperDifficulty;
+  label: string;
+  config: MinesweeperConfig;
+}
+
+export interface MinesweeperAppOptions {
+  difficulty?: MinesweeperDifficulty;
+  presets?: MinesweeperPreset[];
+  engineFactory?: (config: MinesweeperConfig) => MinesweeperEngine;
+}
+
+export interface MinesweeperAppInstance {
+  mount(host: HTMLElement): void;
+  destroy(): void;
+  setDifficulty(difficulty: MinesweeperDifficulty): void;
+  getState(): MinesweeperState;
+}

--- a/win95sim_v2/src/shell/boot/session.ts
+++ b/win95sim_v2/src/shell/boot/session.ts
@@ -12,6 +12,7 @@ import { createDesktopModule, type DesktopEntry } from '@apps/shell/desktop';
 import { createExplorerApp, type ExplorerInstance } from '@apps/explorer';
 import { createPaintApp, type PaintAppInstance } from '@apps/creative/paint';
 import { createNavigatorApp, type NavigatorAppInstance } from '@apps/internet/navigator';
+import { createMinesweeperApp, type MinesweeperAppInstance } from '@apps/games/minesweeper';
 import { createRecentDocumentsService } from '@services/recent-documents';
 import { createCrtViewport } from '@ui/components/crtViewport';
 import { createWindowFrame } from '@ui/components/windowFrame';
@@ -872,6 +873,34 @@ export function createShellSession(): ShellSession {
     return form;
   }
 
+  function launchMinesweeperWindow(options: { id?: string; title?: string; icon?: string } = {}) {
+    let minesweeperInstance: MinesweeperAppInstance | undefined;
+    const descriptor = openWindow({
+      id: options.id,
+      title: options.title ?? 'Minesweeper',
+      icon: options.icon ?? WINDOW_ICONS.minesweeper,
+      width: 820,
+      height: 620,
+      content: () => {
+        const host = document.createElement('div');
+        minesweeperInstance = createMinesweeperApp();
+        minesweeperInstance.mount(host);
+        return host;
+      },
+    });
+    if (minesweeperInstance) {
+      const windowId = descriptor.id;
+      const teardown = appTeardowns.get(windowId);
+      if (teardown) {
+        teardown();
+      }
+      appTeardowns.set(windowId, () => {
+        minesweeperInstance?.destroy();
+      });
+    }
+    return descriptor;
+  }
+
   function launchExplorerWindow(options: { id?: string; title?: string; startPath?: string; icon?: string } = {}) {
     let explorerInstance: ExplorerInstance | undefined;
     const descriptor = openWindow({
@@ -1021,13 +1050,9 @@ export function createShellSession(): ShellSession {
         title: 'Paint',
       }),
     'shell:start:minesweeper': () =>
-      openWindow({
+      launchMinesweeperWindow({
+        id: `app:minesweeper:${windowSequence}`,
         title: 'Minesweeper',
-        icon: WINDOW_ICONS.minesweeper,
-        width: 360,
-        height: 320,
-        content: () =>
-          createPlaceholderContent('Minesweeper', 'Careful! The mines are still being planted in this preview build.'),
       }),
     'shell:start:internet-explorer': () => launchNavigatorWindow(),
     'shell:start:internet-mail': () =>

--- a/win95sim_v2/src/styles/global.css
+++ b/win95sim_v2/src/styles/global.css
@@ -658,6 +658,193 @@ body {
   font-size: 18px;
 }
 
+.app-minesweeper {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100%;
+  background: var(--win95-color-window);
+}
+
+.app-minesweeper__toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 4px 6px;
+  background: #c0c0c0;
+  border: 1px solid #808080;
+  box-shadow:
+    inset 0 1px 0 #ffffff,
+    inset 0 -1px 0 #ffffff;
+}
+
+.app-minesweeper__controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.app-minesweeper__label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+}
+
+.app-minesweeper__select {
+  font-family: var(--win95-font-ui);
+  font-size: 12px;
+  padding: 2px 4px;
+  border: 1px solid #808080;
+  background: #ffffff;
+}
+
+.app-minesweeper__button {
+  font-family: var(--win95-font-ui);
+  font-size: 12px;
+  padding: 2px 10px;
+  border: 1px solid #808080;
+  background: #c0c0c0;
+  box-shadow:
+    inset -1px -1px 0 #000000,
+    inset 1px 1px 0 #ffffff;
+  cursor: default;
+}
+
+.app-minesweeper__button:active {
+  box-shadow:
+    inset 1px 1px 0 #000000,
+    inset -1px -1px 0 #ffffff;
+}
+
+.app-minesweeper__status {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  font-size: 12px;
+}
+
+.app-minesweeper__counter {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 54px;
+  padding: 2px 6px;
+  border: 2px inset #808080;
+  background: #000000;
+  color: #ff0000;
+  font-family: 'Lucida Console', monospace;
+  font-size: 14px;
+  line-height: 1;
+  letter-spacing: 1px;
+}
+
+.app-minesweeper__indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 132px;
+  padding: 2px 8px;
+  border: 2px groove #808080;
+  background: #c0c0c0;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.app-minesweeper__board-wrapper {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: 6px;
+  border: 2px solid #c0c0c0;
+  background: #808080;
+}
+
+.app-minesweeper__board {
+  display: grid;
+  gap: 2px;
+  justify-content: start;
+  grid-auto-rows: 24px;
+}
+
+.app-minesweeper__cell {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  background: #c0c0c0;
+  box-shadow:
+    inset -2px -2px 0 #808080,
+    inset 2px 2px 0 #ffffff;
+  font-family: var(--win95-font-ui);
+  font-size: 14px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.app-minesweeper__cell:focus-visible {
+  outline: 2px solid #000080;
+  outline-offset: -2px;
+}
+
+.app-minesweeper__cell--revealed {
+  background: #c0c0c0;
+  box-shadow:
+    inset 1px 1px 0 #ffffff,
+    inset -1px -1px 0 #808080;
+  cursor: default;
+}
+
+.app-minesweeper__cell--mine {
+  background: #ffcccc;
+}
+
+.app-minesweeper__cell--flagged {
+  color: #d00000;
+}
+
+.app-minesweeper__cell--incorrect {
+  color: #d00000;
+}
+
+.app-minesweeper__cell--number-1 {
+  color: #0000ff;
+}
+
+.app-minesweeper__cell--number-2 {
+  color: #008200;
+}
+
+.app-minesweeper__cell--number-3 {
+  color: #ff0000;
+}
+
+.app-minesweeper__cell--number-4 {
+  color: #000080;
+}
+
+.app-minesweeper__cell--number-5 {
+  color: #800000;
+}
+
+.app-minesweeper__cell--number-6 {
+  color: #008080;
+}
+
+.app-minesweeper__cell--number-7 {
+  color: #000000;
+}
+
+.app-minesweeper__cell--number-8 {
+  color: #808080;
+}
+
 .app-notepad {
   height: 100%;
   display: flex;

--- a/win95sim_v2/tests/phase07-games.test.js
+++ b/win95sim_v2/tests/phase07-games.test.js
@@ -1,6 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const { loadModule } = require('./helpers/loadModule');
+const { withFakeDom } = require('./helpers/fakeDom');
 
 function serializeBoard(board) {
   return board.map((row) => row.map((cell) => (cell.hasMine ? 'M' : String(cell.adjacentMines))).join('')).join('\n');
@@ -77,4 +78,57 @@ test('seeded random generates repeatable sequences', () => {
   const intsA = Array.from({ length: 5 }, (_, index) => rngA.nextInt(0, index + 5));
   const intsB = Array.from({ length: 5 }, (_, index) => rngB.nextInt(0, index + 5));
   assert.deepEqual(intsA, intsB);
+});
+
+test('minesweeper app mounts board, controls, and cleans up', () => {
+  const { createMinesweeperApp } = loadModule('src/apps/games/minesweeper/index.ts');
+
+  withFakeDom(({ document, FakeElement }) => {
+    if (typeof FakeElement.prototype.removeEventListener !== 'function') {
+      FakeElement.prototype.removeEventListener = function removeEventListener(type, handler) {
+        const listeners = this.eventListeners?.get(type);
+        if (listeners) {
+          listeners.delete(handler);
+        }
+      };
+    }
+
+    const host = document.createElement('div');
+    const app = createMinesweeperApp();
+    app.mount(host);
+
+    assert.equal(host.children.length, 1);
+    const root = host.children[0];
+    assert.ok(root.className.includes('app-minesweeper'));
+
+    const findByClass = (node, className) => {
+      if (!node || !node.children) {
+        return undefined;
+      }
+      if (typeof node.className === 'string' && node.className.split(/\s+/).includes(className)) {
+        return node;
+      }
+      for (const child of node.children) {
+        const found = findByClass(child, className);
+        if (found) {
+          return found;
+        }
+      }
+      return undefined;
+    };
+
+    const toolbar = findByClass(root, 'app-minesweeper__toolbar');
+    const board = findByClass(root, 'app-minesweeper__board');
+    const select = findByClass(root, 'app-minesweeper__select');
+    const button = findByClass(root, 'app-minesweeper__button');
+
+    assert.ok(toolbar, 'expected toolbar to render');
+    assert.ok(board, 'expected board to render');
+    assert.ok(select, 'expected difficulty selector');
+    assert.ok(button, 'expected new game button');
+    assert.ok(board.children.length > 0, 'expected board to contain cells');
+
+    app.destroy();
+    assert.equal(host.children.length, 0);
+  });
 });


### PR DESCRIPTION
## Summary
- add a dedicated `createMinesweeperApp` UI module with difficulty presets, timer handling, and cleanup hooks
- integrate the new module into the shell start command and polish the digital counter styling
- document the app entry point, update README highlights, and add a DOM mount test for the Minesweeper UI

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fd3f3521ec8329996e91f3a63ff379