### PR TITLE
Stabilize Paint DOM integration and document VFS support

### DIFF
--- a/win95sim_v2/docs/creative-suite.md
+++ b/win95sim_v2/docs/creative-suite.md
@@ -11,8 +11,9 @@ Phase 06 introduces foundational utilities that future creative and media-focuse
 - Strokes use a Bresenham-based rasteriser and configurable brush size, allowing additional tool implementations (airbrush, shapes) to be layered on top without modifying the core engine.
 
 ### Paint application shell
-- **`@apps/creative/paint`** wraps the engine with a Win95-style UI: toolbar palette swatches, brush sizing, a layered `<canvas>` surface, and status bar feedback.
+- **`@apps/creative/paint`** wraps the engine with a Win95-style UI: toolbar palette swatches, brush sizing, a layered `<canvas>` surface, menu bar, and status bar feedback.
 - The factory `createPaintApp(options)` accepts the same sizing parameters as the engine and mounts/destroys itself without mutating the host DOM node. Downstream phases can embed the app in new shells (e.g., document editors) while reusing the same styling tokens.
+- Paint optionally integrates with the virtual file system by passing a `vfs` service and `defaultDirectory` into `createPaintApp`. When present, the UI lights up Open/Save commands that serialise `.w95p` snapshots through the shared VFS contracts.
 - Tests cover DOM mounting via the fake DOM helper, so new integrations should maintain node-based event listeners rather than reaching for global browser APIs.
 
 ## Media services

--- a/win95sim_v2/docs/module-apis-v2.md
+++ b/win95sim_v2/docs/module-apis-v2.md
@@ -275,11 +275,19 @@ UI shell for the paint engine.
 ```ts
 import { createPaintApp } from '@apps/creative/paint';
 
-const paint = createPaintApp({ width: 480, height: 320, background: [255, 255, 255, 255] });
+const { vfs } = services;
+
+const paint = createPaintApp({
+  width: 480,
+  height: 320,
+  background: [255, 255, 255, 255],
+  vfs,
+  defaultDirectory: 'C:/Documents',
+});
 paint.mount(canvasHost);
 ```
 
-The instance exposes `{ mount(host), destroy() }`. It mounts palette swatches, brush controls, layered `<canvas>` surfaces, and a status bar while delegating undo/redo to `@apps/creative/paint/engine`.
+The instance exposes `{ mount(host), destroy() }`. It mounts palette swatches, brush controls, layered `<canvas>` surfaces, menus, and a status bar while delegating undo/redo to `@apps/creative/paint/engine`. When supplied with a VFS service the File menu activates Open/Save commands that serialise `.w95p` snapshots.
 
 ## UI primitives
 ### CSS tokens (`ui/tokens.css`)

--- a/win95sim_v2/src/apps/creative/paint/index.ts
+++ b/win95sim_v2/src/apps/creative/paint/index.ts
@@ -1,10 +1,13 @@
 import type { PaintColor } from '@services/graphics/bitmap';
 import { normalizeColor } from '@services/graphics/bitmap';
+import type { VfsService } from '@services/vfs';
+import { basename, dirname, isRoot, join, normalizePath } from '@services/vfs/utils/path';
 import {
   createPaintEngine,
   type PaintCommand,
   type PaintEngine,
   type PaintEngineOptions,
+  type PaintEngineSnapshot,
   type StrokePoint,
 } from './engine';
 
@@ -14,6 +17,8 @@ export interface PaintAppOptions {
   background?: PaintColor;
   palette?: PaintColor[];
   engineFactory?: (options: PaintEngineOptions) => PaintEngine;
+  vfs?: VfsService;
+  defaultDirectory?: string;
 }
 
 export interface PaintAppInstance {
@@ -37,19 +42,127 @@ const DEFAULT_PALETTE: PaintColor[] = [
   [112, 48, 160, 255],
 ];
 
+const SNAPSHOT_MAGIC = 'W95P';
+const SNAPSHOT_VERSION = 1;
+const SNAPSHOT_HEADER_BYTES = 16;
+
+interface MenuItemConfig {
+  label?: string;
+  shortcut?: string;
+  disabled?: boolean;
+  action?: () => void | Promise<void>;
+  type?: 'item' | 'separator';
+}
+
+type DialogMode = 'open' | 'save';
+
+function encodeSnapshot(snapshot: PaintEngineSnapshot): Uint8Array {
+  const header = new Uint8Array(SNAPSHOT_HEADER_BYTES + snapshot.pixels.length);
+  header[0] = SNAPSHOT_MAGIC.charCodeAt(0);
+  header[1] = SNAPSHOT_MAGIC.charCodeAt(1);
+  header[2] = SNAPSHOT_MAGIC.charCodeAt(2);
+  header[3] = SNAPSHOT_MAGIC.charCodeAt(3);
+  const view = new DataView(header.buffer);
+  view.setUint32(4, SNAPSHOT_VERSION, true);
+  view.setUint32(8, snapshot.width, true);
+  view.setUint32(12, snapshot.height, true);
+  header.set(snapshot.pixels, SNAPSHOT_HEADER_BYTES);
+  return header;
+}
+
+function decodeSnapshot(payload: Uint8Array): PaintEngineSnapshot {
+  if (payload.byteLength < SNAPSHOT_HEADER_BYTES) {
+    throw new Error('File is not a valid Win95Sim Paint document.');
+  }
+
+  const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
+  const magic = String.fromCharCode(view.getUint8(0), view.getUint8(1), view.getUint8(2), view.getUint8(3));
+  if (magic !== SNAPSHOT_MAGIC) {
+    throw new Error('Unsupported paint file format.');
+  }
+
+  const version = view.getUint32(4, true);
+  if (version !== SNAPSHOT_VERSION) {
+    throw new Error('Unsupported paint file version.');
+  }
+
+  const width = view.getUint32(8, true);
+  const height = view.getUint32(12, true);
+  const expectedPixels = width * height * 4;
+  if (payload.byteLength < SNAPSHOT_HEADER_BYTES + expectedPixels) {
+    throw new Error('Paint file appears to be corrupted.');
+  }
+
+  const pixels = new Uint8ClampedArray(expectedPixels);
+  pixels.set(payload.subarray(SNAPSHOT_HEADER_BYTES, SNAPSHOT_HEADER_BYTES + expectedPixels));
+  return { width, height, pixels };
+}
+
+function ensurePaintExtension(path: string): string {
+  try {
+    const normalized = normalizePath(path);
+    const name = basename(normalized);
+    if (name.toLowerCase().endsWith('.w95p')) {
+      return normalized;
+    }
+    const folder = dirname(normalized);
+    const base = name.includes('.') ? name.slice(0, name.lastIndexOf('.')) : name;
+    const finalName = `${base || 'Untitled'}.w95p`;
+    return folder.endsWith('/') ? `${folder}${finalName}` : `${folder}/${finalName}`;
+  } catch {
+    if (path.toLowerCase().endsWith('.w95p')) {
+      return path;
+    }
+    return `${path}.w95p`;
+  }
+}
+
+function describeDocument(path: string | null): string {
+  if (!path) {
+    return 'Untitled';
+  }
+  try {
+    return basename(normalizePath(path));
+  } catch {
+    const parts = path.replace(/\\/g, '/').split('/');
+    return parts[parts.length - 1] || path;
+  }
+}
+
+function featurePlaceholder(name: string, setStatus: (text: string) => void) {
+  setStatus(`${name} is not yet available.`);
+}
+
 export function createPaintApp(options: PaintAppOptions = {}): PaintAppInstance {
   const palette = options.palette && options.palette.length > 0 ? options.palette.slice() : DEFAULT_PALETTE;
   const engineFactory = options.engineFactory ?? createPaintEngine;
-  const width = Math.max(32, Math.round(options.width ?? DEFAULT_WIDTH));
-  const height = Math.max(32, Math.round(options.height ?? DEFAULT_HEIGHT));
+  let width = Math.max(32, Math.round(options.width ?? DEFAULT_WIDTH));
+  let height = Math.max(32, Math.round(options.height ?? DEFAULT_HEIGHT));
+  const initialWidth = width;
+  const initialHeight = height;
   const background = options.background ?? DEFAULT_BACKGROUND;
+  const vfs = options.vfs;
+
+  let defaultDirectory = 'C:/Documents';
+  if (options.defaultDirectory) {
+    try {
+      defaultDirectory = normalizePath(options.defaultDirectory);
+    } catch {
+      defaultDirectory = 'C:/Documents';
+    }
+  }
 
   let engine = engineFactory({ width, height, background });
 
+  let rootDocument: Document | null = null;
+  let rootWindow: (Window & typeof globalThis) | null = null;
   let container: HTMLElement | null = null;
+  let menuBar: HTMLElement | null = null;
+  let toolbar: HTMLElement | null = null;
+  let surface: HTMLElement | null = null;
+  let frame: HTMLElement | null = null;
   let canvas: HTMLCanvasElement | null = null;
   let overlay: HTMLCanvasElement | null = null;
-  let toolbar: HTMLElement | null = null;
   let statusBar: HTMLElement | null = null;
   let brushInput: HTMLInputElement | null = null;
   let swatches: HTMLButtonElement[] = [];
@@ -60,6 +173,38 @@ export function createPaintApp(options: PaintAppOptions = {}): PaintAppInstance 
   let brushSize = 2;
   let drawing = false;
   let strokePoints: StrokePoint[] = [];
+  let statusMessage = 'Brush ready';
+  let dirty = false;
+  let currentFilePath: string | null = null;
+  let activeMenu: { button: HTMLButtonElement; panel: HTMLElement } | null = null;
+  let menuTeardowns: Array<() => void> = [];
+  const activeModals = new Set<HTMLElement>();
+  const globalTeardowns: Array<() => void> = [];
+
+  function updateStatusBar() {
+    if (!statusBar) {
+      return;
+    }
+    const documentLabel = describeDocument(currentFilePath);
+    const suffix = dirty ? ' (unsaved)' : '';
+    statusBar.textContent = `${statusMessage} — ${documentLabel}${suffix}`;
+    statusBar.title = currentFilePath ?? documentLabel;
+  }
+
+  function setStatus(text: string) {
+    statusMessage = text;
+    updateStatusBar();
+  }
+
+  function markDirty() {
+    dirty = true;
+    updateStatusBar();
+  }
+
+  function markClean() {
+    dirty = false;
+    updateStatusBar();
+  }
 
   function toggleClass(element: HTMLElement, token: string, active: boolean) {
     const tokens = new Set((element.className ?? '').split(/\s+/).filter(Boolean));
@@ -71,25 +216,42 @@ export function createPaintApp(options: PaintAppOptions = {}): PaintAppInstance 
     element.className = Array.from(tokens).join(' ');
   }
 
+  function getDocument(): Document | null {
+    if (rootDocument) {
+      return rootDocument;
+    }
+    if (typeof document !== 'undefined') {
+      return document;
+    }
+    return null;
+  }
+
+  function getWindow(): (Window & typeof globalThis) | null {
+    if (rootWindow) {
+      return rootWindow;
+    }
+    const doc = getDocument();
+    if (doc && doc.defaultView) {
+      return doc.defaultView as Window & typeof globalThis;
+    }
+    if (typeof window !== 'undefined') {
+      return window;
+    }
+    return null;
+  }
+
+  function createElement<K extends keyof HTMLElementTagNameMap>(tag: K): HTMLElementTagNameMap[K] {
+    const doc = getDocument();
+    if (!doc) {
+      throw new Error('Paint app is not mounted.');
+    }
+    return doc.createElement(tag);
+  }
+
   function getCssColor(color: PaintColor): string {
     const [r, g, b, a] = normalizeColor(color);
     const alpha = Math.max(0, Math.min(1, a / 255));
     return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-  }
-
-  function setStatus(text: string) {
-    if (statusBar) {
-      statusBar.textContent = text;
-    }
-  }
-
-  function activateColor(color: PaintColor) {
-    activeColor = color;
-    const encoded = JSON.stringify(color);
-    swatches.forEach((button) => {
-      toggleClass(button, 'app-paint__swatch--active', button.dataset.color === encoded);
-    });
-    setStatus('Brush ready');
   }
 
   function ensureContexts() {
@@ -130,14 +292,47 @@ export function createPaintApp(options: PaintAppOptions = {}): PaintAppInstance 
     }
   }
 
+  function updateCanvasDimensions(nextWidth: number, nextHeight: number) {
+    width = Math.max(32, Math.round(nextWidth));
+    height = Math.max(32, Math.round(nextHeight));
+
+    if (canvas) {
+      canvas.width = width;
+      canvas.height = height;
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+    }
+
+    if (overlay) {
+      overlay.width = width;
+      overlay.height = height;
+      overlay.style.width = `${width}px`;
+      overlay.style.height = `${height}px`;
+    }
+
+    if (frame) {
+      frame.style.width = `${width}px`;
+      frame.style.height = `${height}px`;
+    }
+
+    ctx = null;
+    overlayCtx = null;
+    clearOverlay();
+    ensureContexts();
+    renderBitmap();
+  }
+
   function applyCommand(command: PaintCommand) {
     engine.apply(command);
     renderBitmap();
+    markDirty();
   }
 
   function resetEngine() {
     engine = engineFactory({ width, height, background });
     renderBitmap();
+    clearOverlay();
+    markDirty();
     setStatus('Canvas cleared');
   }
 
@@ -198,7 +393,7 @@ export function createPaintApp(options: PaintAppOptions = {}): PaintAppInstance 
       overlayCtx.lineWidth = Math.max(1, brushSize);
       overlayCtx.moveTo(strokePoints[0].x, strokePoints[0].y);
     }
-    setStatus('Drawing...');
+    setStatus('Drawing…');
   }
 
   function handlePointerMove(event: PointerEvent) {
@@ -211,7 +406,7 @@ export function createPaintApp(options: PaintAppOptions = {}): PaintAppInstance 
     try {
       overlayCtx.stroke();
     } catch {
-      // ignore
+      // Ignore drawing errors.
     }
   }
 
@@ -266,29 +461,705 @@ export function createPaintApp(options: PaintAppOptions = {}): PaintAppInstance 
     layer.removeEventListener('pointercancel', handlePointerLeave);
   }
 
+  function closeMenu() {
+    menuTeardowns.forEach((fn) => fn());
+    menuTeardowns = [];
+    if (!activeMenu) {
+      return;
+    }
+    activeMenu.button.setAttribute('aria-expanded', 'false');
+    activeMenu.panel.remove();
+    activeMenu = null;
+  }
+
+  function openMenu(button: HTMLButtonElement, itemsFactory: () => MenuItemConfig[]) {
+    if (!container) {
+      return;
+    }
+    if (activeMenu && activeMenu.button === button) {
+      closeMenu();
+      return;
+    }
+
+    closeMenu();
+    const items = itemsFactory();
+    if (items.length === 0) {
+      return;
+    }
+
+    const doc = getDocument();
+    const panel = createElement('div');
+    panel.className = 'app-paint__menu';
+    const rect = button.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+    panel.style.left = `${rect.left - containerRect.left}px`;
+    panel.style.top = `${rect.bottom - containerRect.top}px`;
+
+    items.forEach((config) => {
+      if (config.type === 'separator') {
+        const separator = doc.createElement('div');
+        separator.className = 'app-paint__menu-separator';
+        panel.appendChild(separator);
+        return;
+      }
+
+      const entry = doc.createElement('button');
+      entry.type = 'button';
+      entry.className = 'app-paint__menu-entry';
+      entry.textContent = '';
+      if (config.disabled) {
+        entry.classList.add('app-paint__menu-entry--disabled');
+        entry.disabled = true;
+      }
+
+      const label = doc.createElement('span');
+      label.className = 'app-paint__menu-entry-label';
+      label.textContent = config.label ?? '';
+      entry.appendChild(label);
+
+      if (config.shortcut) {
+        const shortcut = doc.createElement('span');
+        shortcut.className = 'app-paint__menu-entry-shortcut';
+        shortcut.textContent = config.shortcut;
+        entry.appendChild(shortcut);
+      }
+
+      entry.addEventListener('click', () => {
+        if (config.disabled) {
+          return;
+        }
+        closeMenu();
+        try {
+          const result = config.action?.();
+          if (result instanceof Promise) {
+            void result.catch((error: unknown) => {
+              if (error instanceof Error) {
+                setStatus(error.message);
+              }
+            });
+          }
+        } catch (error) {
+          if (error instanceof Error) {
+            setStatus(error.message);
+          }
+        }
+      });
+
+      panel.appendChild(entry);
+    });
+
+    container.appendChild(panel);
+    activeMenu = { button, panel };
+    button.setAttribute('aria-expanded', 'true');
+
+    const handlePointer = (event: PointerEvent) => {
+      if (!panel.contains(event.target as Node) && !button.contains(event.target as Node)) {
+        closeMenu();
+      }
+    };
+    const pointerTarget: (Document | HTMLElement) | null =
+      doc && typeof doc.addEventListener === 'function'
+        ? doc
+        : container && typeof container.addEventListener === 'function'
+          ? container
+          : null;
+    pointerTarget?.addEventListener('pointerdown', handlePointer, true);
+    if (pointerTarget) {
+      menuTeardowns.push(() => pointerTarget.removeEventListener('pointerdown', handlePointer, true));
+    }
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closeMenu();
+      }
+    };
+    const keyTarget = pointerTarget;
+    keyTarget?.addEventListener('keydown', handleKey, true);
+    if (keyTarget) {
+      menuTeardowns.push(() => keyTarget.removeEventListener('keydown', handleKey, true));
+    }
+  }
+
+  function confirmDiscard(): boolean {
+    if (!dirty) {
+      return true;
+    }
+    const view = getWindow();
+    if (view && typeof view.confirm === 'function') {
+      return view.confirm('Discard unsaved changes?');
+    }
+    return true;
+  }
+
+  function loadSnapshot(snapshot: PaintEngineSnapshot) {
+    updateCanvasDimensions(snapshot.width, snapshot.height);
+    engine = engineFactory({ width, height, background });
+    const bitmap = engine.getBitmap();
+    if (bitmap.data.length === snapshot.pixels.length) {
+      bitmap.data.set(snapshot.pixels);
+    } else {
+      const length = Math.min(bitmap.data.length, snapshot.pixels.length);
+      bitmap.data.set(snapshot.pixels.subarray(0, length));
+    }
+    renderBitmap();
+    clearOverlay();
+    markClean();
+  }
+
+  async function persistToPath(path: string): Promise<void> {
+    if (!vfs) {
+      setStatus('File system integration is unavailable.');
+      return;
+    }
+    const normalized = normalizePath(ensurePaintExtension(path));
+    const snapshot = engine.export();
+    const payload = encodeSnapshot(snapshot);
+    await vfs.writeFile(normalized, payload, { app: 'paint', format: 'win95paint' });
+    currentFilePath = normalized;
+    markClean();
+    setStatus(`Saved ${describeDocument(currentFilePath)}`);
+  }
+
+  async function handleSaveDocument(): Promise<void> {
+    if (!vfs) {
+      setStatus('File system integration is unavailable.');
+      return;
+    }
+    if (!dirty && currentFilePath) {
+      setStatus('No changes to save.');
+      return;
+    }
+    if (!currentFilePath) {
+      await handleSaveDocumentAs();
+      return;
+    }
+    try {
+      await persistToPath(currentFilePath);
+    } catch (error) {
+      if (error instanceof Error) {
+        setStatus(`Save failed: ${error.message}`);
+      }
+    }
+  }
+
+  async function handleSaveDocumentAs(): Promise<void> {
+    if (!vfs) {
+      setStatus('File system integration is unavailable.');
+      return;
+    }
+    const seed = currentFilePath ?? join(defaultDirectory, 'Untitled.w95p');
+    const selected = await promptForPath('save', seed);
+    if (!selected) {
+      return;
+    }
+    try {
+      await persistToPath(selected);
+    } catch (error) {
+      if (error instanceof Error) {
+        setStatus(`Save failed: ${error.message}`);
+      }
+    }
+  }
+
+  async function handleOpenDocument(): Promise<void> {
+    if (!vfs) {
+      setStatus('File system integration is unavailable.');
+      return;
+    }
+    if (!confirmDiscard()) {
+      return;
+    }
+    const seed = currentFilePath ?? defaultDirectory;
+    const selected = await promptForPath('open', seed);
+    if (!selected) {
+      return;
+    }
+    try {
+      const node = await vfs.read(selected);
+      if (node.kind !== 'file') {
+        throw new Error('Selected item is not a paint document.');
+      }
+      const snapshot = decodeSnapshot(node.content);
+      currentFilePath = normalizePath(selected);
+      loadSnapshot(snapshot);
+      setStatus(`Opened ${describeDocument(currentFilePath)}`);
+    } catch (error) {
+      if (error instanceof Error) {
+        setStatus(`Open failed: ${error.message}`);
+      } else {
+        setStatus('Open failed.');
+      }
+    }
+  }
+
+  function handleNewDocument() {
+    if (!confirmDiscard()) {
+      return;
+    }
+    width = initialWidth;
+    height = initialHeight;
+    updateCanvasDimensions(width, height);
+    engine = engineFactory({ width, height, background });
+    currentFilePath = null;
+    markClean();
+    renderBitmap();
+    setStatus('New canvas ready');
+  }
+
+  function handleCloseWindow() {
+    if (!container) {
+      return;
+    }
+    const frameElement = container.closest('.window-frame');
+    const closeButton = frameElement?.querySelector('.window-frame__control--close, [data-window-control="close"]');
+    if (closeButton instanceof HTMLButtonElement) {
+      closeButton.click();
+      return;
+    }
+    if (frameElement) {
+      frameElement.dispatchEvent(new CustomEvent('window:close-request', { bubbles: true }));
+    }
+  }
+
+  function handleUndo() {
+    if (engine.undo()) {
+      renderBitmap();
+      clearOverlay();
+      markDirty();
+      setStatus('Undo completed');
+    } else {
+      setStatus('Nothing to undo');
+    }
+  }
+
+  function handleRedo() {
+    if (engine.redo()) {
+      renderBitmap();
+      clearOverlay();
+      markDirty();
+      setStatus('Redo completed');
+    } else {
+      setStatus('Nothing to redo');
+    }
+  }
+
+  function bindGlobalShortcuts() {
+    const doc = getDocument();
+    const handler = (event: KeyboardEvent) => {
+      if (!container) {
+        return;
+      }
+      if (!event.ctrlKey || event.altKey) {
+        return;
+      }
+      const frameElement = container.closest('.window-frame');
+      if (!frameElement || frameElement.getAttribute('data-active') !== 'true') {
+        return;
+      }
+      const key = event.key.toLowerCase();
+      switch (key) {
+        case 's':
+          event.preventDefault();
+          void handleSaveDocument();
+          break;
+        case 'o':
+          event.preventDefault();
+          void handleOpenDocument();
+          break;
+        case 'n':
+          event.preventDefault();
+          handleNewDocument();
+          break;
+        case 'z':
+          event.preventDefault();
+          handleUndo();
+          break;
+        case 'y':
+          event.preventDefault();
+          handleRedo();
+          break;
+        default:
+          break;
+      }
+    };
+    const target: (Document | HTMLElement) | null =
+      doc && typeof doc.addEventListener === 'function'
+        ? doc
+        : container && typeof container.addEventListener === 'function'
+          ? container
+          : null;
+    if (!target) {
+      return;
+    }
+    target.addEventListener('keydown', handler as EventListener);
+    globalTeardowns.push(() => target.removeEventListener('keydown', handler as EventListener));
+  }
+
+  function createFileMenuItems(): MenuItemConfig[] {
+    return [
+      { label: 'New', shortcut: 'Ctrl+N', action: handleNewDocument },
+      { label: 'Open…', shortcut: 'Ctrl+O', action: () => void handleOpenDocument(), disabled: !vfs },
+      { label: 'Save', shortcut: 'Ctrl+S', action: () => void handleSaveDocument(), disabled: !vfs },
+      { label: 'Save As…', action: () => void handleSaveDocumentAs(), disabled: !vfs },
+      { type: 'separator' },
+      { label: 'Exit', action: handleCloseWindow },
+    ];
+  }
+
+  function createEditMenuItems(): MenuItemConfig[] {
+    return [
+      { label: 'Undo', shortcut: 'Ctrl+Z', action: handleUndo, disabled: !engine.canUndo() },
+      { label: 'Redo', shortcut: 'Ctrl+Y', action: handleRedo, disabled: !engine.canRedo() },
+      { type: 'separator' },
+      { label: 'Clear Canvas', action: resetEngine },
+    ];
+  }
+
+  function createPlaceholderMenu(label: string): MenuItemConfig[] {
+    return [
+      {
+        label: `${label} commands`,
+        disabled: true,
+      },
+      { type: 'separator' },
+      {
+        label: 'Coming soon…',
+        disabled: true,
+      },
+    ];
+  }
+
+  function promptForPath(mode: DialogMode, seed?: string): Promise<string | undefined> {
+    if (!container || !vfs) {
+      return Promise.resolve(undefined);
+    }
+
+    closeMenu();
+
+    return new Promise((resolve) => {
+      const overlayElement = createElement('div');
+      overlayElement.className = 'app-paint__modal';
+
+      const dialog = createElement('div');
+      dialog.className = 'app-paint__dialog';
+      overlayElement.appendChild(dialog);
+
+      container.appendChild(overlayElement);
+      activeModals.add(overlayElement);
+
+      const header = createElement('div');
+      header.className = 'app-paint__dialog-header';
+      header.textContent = mode === 'open' ? 'Open Picture' : 'Save Picture';
+      dialog.appendChild(header);
+
+      const body = createElement('div');
+      body.className = 'app-paint__dialog-body';
+      dialog.appendChild(body);
+
+      const directoryRow = createElement('div');
+      directoryRow.className = 'app-paint__dialog-directory';
+      body.appendChild(directoryRow);
+
+      const directoryLabel = createElement('div');
+      directoryLabel.className = 'app-paint__dialog-directory-path';
+      directoryRow.appendChild(directoryLabel);
+
+      const upButton = createElement('button');
+      upButton.type = 'button';
+      upButton.className = 'app-paint__dialog-button';
+      upButton.textContent = 'Up';
+      directoryRow.appendChild(upButton);
+
+      const list = createElement('div');
+      list.className = 'app-paint__dialog-list';
+      body.appendChild(list);
+
+      const field = createElement('label');
+      field.className = 'app-paint__dialog-field';
+      const fieldLabel = createElement('span');
+      fieldLabel.textContent = 'File name:';
+      const input = createElement('input');
+      input.type = 'text';
+      input.className = 'app-paint__dialog-input';
+      field.appendChild(fieldLabel);
+      field.appendChild(input);
+      body.appendChild(field);
+
+      const message = createElement('div');
+      message.className = 'app-paint__dialog-message';
+      body.appendChild(message);
+
+      const footer = createElement('div');
+      footer.className = 'app-paint__dialog-footer';
+      dialog.appendChild(footer);
+
+      const confirmButton = createElement('button');
+      confirmButton.type = 'button';
+      confirmButton.className = 'app-paint__dialog-button';
+      confirmButton.textContent = mode === 'open' ? 'Open' : 'Save';
+      footer.appendChild(confirmButton);
+
+      const cancelButton = createElement('button');
+      cancelButton.type = 'button';
+      cancelButton.className = 'app-paint__dialog-button';
+      cancelButton.textContent = 'Cancel';
+      footer.appendChild(cancelButton);
+
+      let settled = false;
+      let currentDirectory = defaultDirectory;
+      let renderToken = 0;
+
+      function cleanup() {
+        activeModals.delete(overlayElement);
+        overlayElement.remove();
+      }
+
+      function finish(result: string | undefined) {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        resolve(result);
+      }
+
+      function showMessage(text: string) {
+        message.textContent = text;
+      }
+
+      function clearMessage() {
+        message.textContent = '';
+      }
+
+      function resolveRelative(path: string): string {
+        try {
+          return normalizePath(path);
+        } catch {
+          return join(currentDirectory, path);
+        }
+      }
+
+      function submit(selectedPath?: string) {
+        clearMessage();
+        let candidate = selectedPath ?? input.value.trim();
+        if (!candidate) {
+          showMessage('Enter a file name.');
+          return;
+        }
+        try {
+          let target = resolveRelative(candidate);
+          if (mode === 'save') {
+            target = ensurePaintExtension(target);
+          } else {
+            target = normalizePath(target);
+          }
+          finish(target);
+        } catch {
+          showMessage('Enter a valid absolute path (e.g. C:/Pictures/Image.w95p).');
+        }
+      }
+
+      function applySeed() {
+        if (!seed) {
+          currentDirectory = defaultDirectory;
+          directoryLabel.textContent = currentDirectory;
+          return;
+        }
+        try {
+          const normalizedSeed = normalizePath(seed);
+          if (mode === 'save') {
+            currentDirectory = dirname(normalizedSeed);
+            const name = basename(normalizedSeed);
+            if (name && !name.endsWith('/')) {
+              input.value = name;
+            }
+          } else {
+            currentDirectory = seed.endsWith('/') ? normalizedSeed : dirname(normalizedSeed);
+            if (!seed.endsWith('/')) {
+              input.value = basename(normalizedSeed);
+            }
+          }
+        } catch {
+          currentDirectory = defaultDirectory;
+        }
+        directoryLabel.textContent = currentDirectory;
+      }
+
+      function renderEntries() {
+        const token = ++renderToken;
+        list.innerHTML = '';
+        directoryLabel.textContent = currentDirectory;
+        const loading = createElement('div');
+        loading.className = 'app-paint__dialog-empty';
+        loading.textContent = 'Loading…';
+        list.appendChild(loading);
+
+        vfs
+          .list(currentDirectory)
+          .then((entries) => {
+            if (settled || token !== renderToken) {
+              return;
+            }
+            list.innerHTML = '';
+            const sorted = entries.slice().sort((a, b) => {
+              if (a.kind === b.kind) {
+                return a.name.localeCompare(b.name);
+              }
+              if (a.kind === 'directory') {
+                return -1;
+              }
+              if (b.kind === 'directory') {
+                return 1;
+              }
+              return a.name.localeCompare(b.name);
+            });
+
+            if (sorted.length === 0) {
+              const empty = createElement('div');
+              empty.className = 'app-paint__dialog-empty';
+              empty.textContent = 'This folder is empty.';
+              list.appendChild(empty);
+              return;
+            }
+
+            sorted.forEach((entry) => {
+              const item = createElement('button');
+              item.type = 'button';
+              item.className = 'app-paint__dialog-list-item';
+              item.dataset.path = entry.path;
+              item.textContent = entry.name;
+              if (entry.kind === 'directory') {
+                item.classList.add('app-paint__dialog-list-item--directory');
+                item.addEventListener('click', () => {
+                  currentDirectory = entry.path;
+                  renderEntries();
+                });
+                item.addEventListener('dblclick', () => {
+                  currentDirectory = entry.path;
+                  renderEntries();
+                });
+              } else {
+                item.classList.add('app-paint__dialog-list-item--file');
+                item.addEventListener('click', () => {
+                  input.value = entry.name;
+                  clearMessage();
+                });
+                item.addEventListener('dblclick', () => submit(entry.path));
+              }
+              list.appendChild(item);
+            });
+          })
+          .catch(() => {
+            if (settled || token !== renderToken) {
+              return;
+            }
+            list.innerHTML = '';
+            const failure = createElement('div');
+            failure.className = 'app-paint__dialog-empty';
+            failure.textContent = 'Unable to open folder.';
+            list.appendChild(failure);
+          });
+      }
+
+      upButton.addEventListener('click', () => {
+        try {
+          if (isRoot(currentDirectory)) {
+            return;
+          }
+          currentDirectory = dirname(currentDirectory);
+          renderEntries();
+        } catch {
+          // ignore invalid navigation
+        }
+      });
+
+      confirmButton.addEventListener('click', () => submit());
+      cancelButton.addEventListener('click', () => finish(undefined));
+
+      input.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          submit();
+        }
+      });
+
+      overlayElement.addEventListener('pointerdown', (event) => {
+        if (event.target === overlayElement) {
+          event.stopPropagation();
+          finish(undefined);
+        }
+      });
+
+      overlayElement.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          finish(undefined);
+        }
+      });
+
+      applySeed();
+      renderEntries();
+      setTimeout(() => input.focus(), 0);
+    });
+  }
+
+  function buildMenuBar(): HTMLElement {
+    const bar = createElement('div');
+    bar.className = 'app-paint__menubar';
+
+    const createButton = (label: string, factory: () => MenuItemConfig[]) => {
+      const button = createElement('button');
+      button.type = 'button';
+      button.className = 'app-paint__menubar-button';
+      button.textContent = label;
+      button.addEventListener('click', () => openMenu(button, factory));
+      bar.appendChild(button);
+      return button;
+    };
+
+    createButton('File', createFileMenuItems);
+    createButton('Edit', createEditMenuItems);
+    createButton('Image', () => createPlaceholderMenu('Image'));
+    createButton('Colors', () => createPlaceholderMenu('Colors'));
+    createButton('Help', () => [
+      {
+        label: 'About Paint…',
+        action: () => featurePlaceholder('Help', setStatus),
+      },
+    ]);
+
+    return bar;
+  }
+
   function buildToolbar(): HTMLElement {
-    const bar = document.createElement('div');
+    const bar = createElement('div');
     bar.className = 'app-paint__toolbar';
 
-    const paletteContainer = document.createElement('div');
+    const paletteContainer = createElement('div');
     paletteContainer.className = 'app-paint__palette';
 
     swatches = palette.map((color) => {
-      const button = document.createElement('button');
+      const button = createElement('button');
       button.type = 'button';
       button.className = 'app-paint__swatch';
       button.dataset.color = JSON.stringify(color);
       button.style.background = getCssColor(color);
-      button.addEventListener('click', () => activateColor(color));
+      button.addEventListener('click', () => {
+        activeColor = color;
+        const encoded = JSON.stringify(color);
+        swatches.forEach((entry) => {
+          toggleClass(entry, 'app-paint__swatch--active', entry.dataset.color === encoded);
+        });
+        setStatus('Brush ready');
+      });
       paletteContainer.appendChild(button);
       return button;
     });
 
-    const brushGroup = document.createElement('label');
+    const brushGroup = createElement('label');
     brushGroup.className = 'app-paint__brush';
     brushGroup.textContent = 'Brush:';
 
-    brushInput = document.createElement('input');
+    brushInput = createElement('input');
     brushInput.type = 'number';
     brushInput.min = '1';
     brushInput.max = '20';
@@ -303,7 +1174,7 @@ export function createPaintApp(options: PaintAppOptions = {}): PaintAppInstance 
     });
     brushGroup.appendChild(brushInput);
 
-    const clearButton = document.createElement('button');
+    const clearButton = createElement('button');
     clearButton.type = 'button';
     clearButton.className = 'app-paint__button';
     clearButton.textContent = 'Clear';
@@ -317,21 +1188,27 @@ export function createPaintApp(options: PaintAppOptions = {}): PaintAppInstance 
   }
 
   function buildCanvas(): HTMLElement {
-    const surface = document.createElement('div');
+    surface = createElement('div');
     surface.className = 'app-paint__surface';
 
-    const frame = document.createElement('div');
+    frame = createElement('div');
     frame.className = 'app-paint__canvas';
+    frame.style.width = `${width}px`;
+    frame.style.height = `${height}px`;
 
-    canvas = document.createElement('canvas');
+    canvas = createElement('canvas');
     canvas.className = 'app-paint__layer';
     canvas.width = width;
     canvas.height = height;
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
 
-    overlay = document.createElement('canvas');
+    overlay = createElement('canvas');
     overlay.className = 'app-paint__layer app-paint__layer--overlay';
     overlay.width = width;
     overlay.height = height;
+    overlay.style.width = `${width}px`;
+    overlay.style.height = `${height}px`;
 
     frame.appendChild(canvas);
     frame.appendChild(overlay);
@@ -345,45 +1222,71 @@ export function createPaintApp(options: PaintAppOptions = {}): PaintAppInstance 
   }
 
   function buildStatus(): HTMLElement {
-    const status = document.createElement('div');
+    const status = createElement('div');
     status.className = 'app-paint__status';
-    status.textContent = 'Brush ready';
+    status.textContent = 'Brush ready — Untitled';
     return status;
   }
 
   return {
     mount(host) {
-      container = document.createElement('div');
+      const doc = host.ownerDocument ?? getDocument();
+      if (!doc) {
+        throw new Error('Cannot mount Paint app without a document context.');
+      }
+      rootDocument = doc;
+      rootWindow = doc.defaultView ?? (typeof window !== 'undefined' ? window : null);
+
+      container = doc.createElement('div');
       container.className = 'app-paint';
+
+      menuBar = buildMenuBar();
+      container.appendChild(menuBar);
 
       toolbar = buildToolbar();
       container.appendChild(toolbar);
 
-      const surface = buildCanvas();
-      container.appendChild(surface);
+      const canvasSurface = buildCanvas();
+      container.appendChild(canvasSurface);
 
       statusBar = buildStatus();
       container.appendChild(statusBar);
 
-      activateColor(activeColor);
+      swatches.forEach((button) => {
+        toggleClass(button, 'app-paint__swatch--active', button.dataset.color === JSON.stringify(activeColor));
+      });
+
       host.innerHTML = '';
       host.appendChild(container);
+      markClean();
+      setStatus('Brush ready');
+      bindGlobalShortcuts();
     },
     destroy() {
+      closeMenu();
+      activeModals.forEach((modal) => modal.remove());
+      activeModals.clear();
+      globalTeardowns.forEach((teardown) => teardown());
+      globalTeardowns.length = 0;
       detachCanvasEvents(overlay);
       if (container && container.parentElement) {
         container.parentElement.removeChild(container);
       }
       container = null;
+      menuBar = null;
+      toolbar = null;
+      surface = null;
+      frame = null;
       canvas = null;
       overlay = null;
-      toolbar = null;
       statusBar = null;
       brushInput = null;
       swatches = [];
       ctx = null;
       overlayCtx = null;
       strokePoints = [];
+      rootDocument = null;
+      rootWindow = null;
     },
   };
 }

--- a/win95sim_v2/src/shell/boot/session.ts
+++ b/win95sim_v2/src/shell/boot/session.ts
@@ -916,6 +916,8 @@ export function createShellSession(): ShellSession {
         paintInstance = createPaintApp({
           width: 480,
           height: 320,
+          vfs,
+          defaultDirectory: 'C:/Documents',
         });
         paintInstance.mount(host);
         return host;

--- a/win95sim_v2/src/styles/global.css
+++ b/win95sim_v2/src/styles/global.css
@@ -948,6 +948,39 @@ body {
   flex-direction: column;
   height: 100%;
   gap: 6px;
+  position: relative;
+  min-height: 0;
+}
+
+.app-paint__menubar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 4px;
+  background: #c0c0c0;
+  border: 1px solid #808080;
+  box-shadow:
+    inset 1px 1px 0 #ffffff,
+    inset -1px -1px 0 #404040;
+}
+
+.app-paint__menubar-button {
+  padding: 2px 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  font-family: var(--win95-font-ui);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.app-paint__menubar-button:hover,
+.app-paint__menubar-button:focus-visible,
+.app-paint__menubar-button[aria-expanded='true'] {
+  border: 1px solid #000000;
+  border-right-color: #ffffff;
+  border-bottom-color: #ffffff;
+  background: linear-gradient(180deg, #ffffff, #c0c0c0);
+  outline: none;
 }
 
 .app-paint__toolbar {
@@ -1033,11 +1066,17 @@ body {
     inset 1px 1px 0 #ffffff,
     inset -1px -1px 0 #404040;
   display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: auto;
 }
 
 .app-paint__canvas {
   position: relative;
-  flex: 1;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
   border: 1px solid #808080;
   box-shadow:
     inset 1px 1px 0 #ffffff,
@@ -1051,10 +1090,216 @@ body {
   width: 100%;
   height: 100%;
   image-rendering: pixelated;
+  cursor: crosshair;
 }
 
 .app-paint__layer--overlay {
   pointer-events: auto;
+}
+
+.app-paint__menu {
+  position: absolute;
+  background: #c0c0c0;
+  border: 1px solid #000000;
+  border-right-color: #ffffff;
+  border-bottom-color: #ffffff;
+  box-shadow: 2px 2px 0 #404040;
+  display: flex;
+  flex-direction: column;
+  padding: 2px;
+  min-width: 180px;
+  z-index: 40;
+}
+
+.app-paint__menu-entry {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2px 18px 2px 24px;
+  border: none;
+  background: transparent;
+  font-family: var(--win95-font-ui);
+  font-size: 12px;
+  text-align: left;
+  color: #000000;
+  cursor: default;
+}
+
+.app-paint__menu-entry-label {
+  flex: 1;
+}
+
+.app-paint__menu-entry:focus-visible {
+  outline: none;
+}
+
+.app-paint__menu-entry:hover:not(.app-paint__menu-entry--disabled),
+.app-paint__menu-entry:focus-visible:not(.app-paint__menu-entry--disabled) {
+  background: #000080;
+  color: #ffffff;
+}
+
+.app-paint__menu-entry--disabled {
+  color: #808080;
+  pointer-events: none;
+}
+
+.app-paint__menu-entry-shortcut {
+  margin-left: 16px;
+}
+
+.app-paint__menu-separator {
+  height: 1px;
+  margin: 4px;
+  background: #808080;
+  box-shadow: 0 1px 0 #ffffff;
+}
+
+.app-paint__modal {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 60;
+}
+
+.app-paint__dialog {
+  width: min(360px, 90%);
+  background: #c0c0c0;
+  border: 2px solid #000000;
+  border-right-color: #ffffff;
+  border-bottom-color: #ffffff;
+  box-shadow: 2px 2px 0 #404040;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-paint__dialog-header {
+  padding: 6px 8px;
+  background: linear-gradient(180deg, #000080, #000040);
+  color: #ffffff;
+  font-weight: bold;
+  font-size: 13px;
+}
+
+.app-paint__dialog-body {
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.app-paint__dialog-directory {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.app-paint__dialog-directory-path {
+  flex: 1;
+  border: 1px solid #808080;
+  border-right-color: #ffffff;
+  border-bottom-color: #ffffff;
+  background: #ffffff;
+  padding: 2px 4px;
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-paint__dialog-button {
+  padding: 2px 10px;
+  border: 1px solid #000000;
+  border-right-color: #ffffff;
+  border-bottom-color: #ffffff;
+  background: linear-gradient(180deg, #fdfdfd, #c0c0c0);
+  font-family: var(--win95-font-ui);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.app-paint__dialog-button:active {
+  border-top-color: #808080;
+  border-left-color: #808080;
+  border-right-color: #ffffff;
+  border-bottom-color: #ffffff;
+  background: linear-gradient(180deg, #c0c0c0, #fdfdfd);
+}
+
+.app-paint__dialog-list {
+  border: 1px solid #808080;
+  border-right-color: #ffffff;
+  border-bottom-color: #ffffff;
+  background: #ffffff;
+  min-height: 140px;
+  max-height: 220px;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-paint__dialog-list-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: none;
+  background: transparent;
+  padding: 2px 6px;
+  font-family: var(--win95-font-ui);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+  color: #000000;
+}
+
+.app-paint__dialog-list-item:hover,
+.app-paint__dialog-list-item:focus-visible {
+  background: #000080;
+  color: #ffffff;
+  outline: none;
+}
+
+.app-paint__dialog-list-item--directory {
+  font-weight: bold;
+}
+
+.app-paint__dialog-field {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.app-paint__dialog-input {
+  flex: 1;
+  border: 1px solid #808080;
+  border-right-color: #ffffff;
+  border-bottom-color: #ffffff;
+  padding: 2px 4px;
+  font-family: var(--win95-font-ui);
+  font-size: 12px;
+}
+
+.app-paint__dialog-message {
+  min-height: 16px;
+  font-size: 11px;
+  color: #800000;
+}
+
+.app-paint__dialog-footer {
+  padding: 8px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.app-paint__dialog-empty {
+  padding: 6px 8px;
+  font-size: 12px;
+  color: #555555;
 }
 
 .app-paint__status {


### PR DESCRIPTION
## Summary
- refactor the Paint app to derive DOM references from the mounting context and guard global listeners so menus and shortcuts work in simulated environments
- build the in-app file picker with host-created elements while continuing to integrate with the virtual file system for open/save operations
- document the Paint UI and VFS options in the creative-suite overview and module API reference

## Testing
- npm run build --prefix win95sim_v2
- npm test --prefix win95sim_v2

------
https://chatgpt.com/codex/tasks/task_e_68fd3f6af61883298b49d08a8e901fdf