### PR TITLE
Restore Win95 chrome in recycle bin

### DIFF
--- a/win95sim_v2/build-info.json
+++ b/win95sim_v2/build-info.json
@@ -1,4 +1,4 @@
 {
-  "lastCommit": "8673f9b1c008991d6728050f27cef902934b32c9",
-  "buildNumber": 3
+  "lastCommit": "58a7cd02470851e8f199fe6cde464accd1bc9d7b",
+  "buildNumber": 4
 }

--- a/win95sim_v2/docs/explorer-integration.md
+++ b/win95sim_v2/docs/explorer-integration.md
@@ -29,6 +29,15 @@ Paths are normalised (`C:/Folder/File.txt`) and drives are case insensitive.
 - Breadcrumb navigation emits `setPath` calls that downstream tooling can hook
   into for automation or testing.
 
+## Recycle Bin app
+- Mounted from `src/apps/system/recycle-bin/index.ts` and consumes the shared
+  VFS recycle bin surface to stay in sync with deletions and restores.
+- Presents a Win95-style chrome including File/Edit/View/Help menus, a command
+  toolbar, and a status bar with live object/size totals so QA scripts can match
+  the legacy simulator layout.
+- Emits the same `vfs:recycle-bin:*` events as Explorer, allowing desktop icons
+  and other apps to refresh when the bin changes state.
+
 ## Fixtures
 `tests/fixtures/vfs/sampleTree.js` exports a helper that returns a seed array
 compatible with `createVfsService({ seed })`. Other phases can reuse the fixture

--- a/win95sim_v2/src/apps/explorer/index.ts
+++ b/win95sim_v2/src/apps/explorer/index.ts
@@ -28,6 +28,7 @@ export function createExplorerApp(options: ExplorerOptions): ExplorerInstance {
   let detailWatcher: (() => void) | null = null;
   const teardown: Array<() => void> = [];
   let treeRenderToken = 0;
+  const selectedPaths = new Set<string>();
 
   function normalize(path: string): string {
     return path.replace(/\\/g, '/');
@@ -41,6 +42,77 @@ export function createExplorerApp(options: ExplorerOptions): ExplorerInstance {
     treePane = null;
     detailsPane = null;
     breadcrumbs = null;
+  }
+
+  function focusDetailsPane() {
+    detailsPane?.focus({ preventScroll: true });
+  }
+
+  function updateSelectionStyles() {
+    if (!detailsPane) {
+      return;
+    }
+    let nodes: HTMLElement[] = [];
+    if (typeof detailsPane.querySelectorAll === 'function') {
+      nodes = Array.from(detailsPane.querySelectorAll<HTMLElement>('.win95-explorer__details-item'));
+    } else {
+      const rawChildren = (detailsPane as unknown as { children?: unknown }).children;
+      if (Array.isArray(rawChildren)) {
+        nodes = rawChildren as HTMLElement[];
+      } else if (rawChildren && typeof (rawChildren as { length: number }).length === 'number') {
+        nodes = Array.from(rawChildren as ArrayLike<HTMLElement>);
+      }
+    }
+    nodes.forEach((node) => {
+      const dataset = (node as HTMLElement & { dataset?: Record<string, string> }).dataset;
+      const path = dataset?.path ?? '';
+      if (!path) {
+        return;
+      }
+      if (selectedPaths.has(path)) {
+        if (dataset) {
+          dataset.selected = 'true';
+        }
+      } else if (dataset && Object.prototype.hasOwnProperty.call(dataset, 'selected')) {
+        delete dataset.selected;
+      }
+    });
+  }
+
+  function clearSelection() {
+    selectedPaths.clear();
+    updateSelectionStyles();
+  }
+
+  function selectEntry(path: string, options: { additive?: boolean } = {}) {
+    const additive = options.additive ?? false;
+    if (!additive) {
+      selectedPaths.clear();
+    }
+    if (additive && selectedPaths.has(path)) {
+      selectedPaths.delete(path);
+    } else {
+      selectedPaths.add(path);
+    }
+    updateSelectionStyles();
+    focusDetailsPane();
+  }
+
+  function deleteSelection() {
+    if (selectedPaths.size === 0) {
+      return;
+    }
+    const targets = Array.from(selectedPaths);
+    clearSelection();
+    void (async () => {
+      for (const target of targets) {
+        try {
+          await vfs.remove(target);
+        } catch (error) {
+          console.error('Failed to delete', target, error);
+        }
+      }
+    })();
   }
 
   async function buildTree(path: string, depth = 0): Promise<ExplorerTreeNode> {
@@ -139,6 +211,14 @@ export function createExplorerApp(options: ExplorerOptions): ExplorerInstance {
     item.dataset.path = entry.path;
     item.dataset.kind = entry.kind;
     item.textContent = entry.name;
+    if (selectedPaths.has(entry.path)) {
+      item.dataset.selected = 'true';
+    }
+    item.addEventListener('click', (event) => {
+      event.preventDefault();
+      const additive = event.ctrlKey || event.metaKey;
+      selectEntry(entry.path, { additive });
+    });
     if (entry.kind === 'directory') {
       item.addEventListener('dblclick', () => {
         void setPath(entry.path);
@@ -170,6 +250,7 @@ export function createExplorerApp(options: ExplorerOptions): ExplorerInstance {
       .forEach((entry) => {
         detailsPane!.appendChild(renderListItem(entry));
       });
+    updateSelectionStyles();
   }
 
   function bindDetailWatcher() {
@@ -187,6 +268,7 @@ export function createExplorerApp(options: ExplorerOptions): ExplorerInstance {
     if (container) {
       container.dataset.path = currentPath;
     }
+    clearSelection();
     bindDetailWatcher();
     renderBreadcrumbs(currentPath);
     await renderDetails();
@@ -216,6 +298,18 @@ export function createExplorerApp(options: ExplorerOptions): ExplorerInstance {
 
     detailsPane = document.createElement('div');
     detailsPane.className = 'win95-explorer__details';
+    detailsPane.tabIndex = 0;
+    detailsPane.addEventListener('keydown', (event) => {
+      if (event.key === 'Delete') {
+        event.preventDefault();
+        deleteSelection();
+      }
+    });
+    detailsPane.addEventListener('click', (event) => {
+      if (event.target === detailsPane) {
+        clearSelection();
+      }
+    });
     content.appendChild(detailsPane);
 
     layout.appendChild(content);
@@ -241,6 +335,7 @@ export function createExplorerApp(options: ExplorerOptions): ExplorerInstance {
     }
 
     teardown.splice(0).forEach((fn) => fn());
+    selectedPaths.clear();
     if (container) {
       container.remove();
     }

--- a/win95sim_v2/src/apps/system/recycle-bin/index.ts
+++ b/win95sim_v2/src/apps/system/recycle-bin/index.ts
@@ -1,0 +1,322 @@
+import type { VfsRecycleBinEntry, VfsService } from '@services/vfs';
+
+export interface RecycleBinAppOptions {
+  vfs: VfsService;
+}
+
+export interface RecycleBinAppInstance {
+  mount(host: HTMLElement): void;
+  destroy(): void;
+}
+
+function formatDeletedAt(timestamp: number): string {
+  const date = new Date(timestamp);
+  try {
+    return date.toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' });
+  } catch {
+    return date.toLocaleString();
+  }
+}
+
+export function createRecycleBinApp(options: RecycleBinAppOptions): RecycleBinAppInstance {
+  const vfs = options.vfs;
+  let container: HTMLElement | null = null;
+  let listHost: HTMLElement | null = null;
+  let emptyState: HTMLElement | null = null;
+  let restoreButton: HTMLButtonElement | null = null;
+  let emptyButton: HTMLButtonElement | null = null;
+  let statusCount: HTMLElement | null = null;
+  let statusSize: HTMLElement | null = null;
+  let selectedId: string | null = null;
+  const teardown: Array<() => void> = [];
+  let currentEntries: VfsRecycleBinEntry[] = [];
+
+  function getEntries(): VfsRecycleBinEntry[] {
+    return vfs
+      .recycleBin
+      .list()
+      .slice()
+      .sort((a, b) => b.deletedAt - a.deletedAt);
+  }
+
+  function updateActions(entries: VfsRecycleBinEntry[]) {
+    if (restoreButton) {
+      restoreButton.disabled = !selectedId;
+    }
+    if (emptyButton) {
+      emptyButton.disabled = entries.length === 0;
+    }
+  }
+
+  function formatSize(bytes: number): string {
+    if (bytes <= 0) {
+      return '0 bytes';
+    }
+
+    const units = ['bytes', 'KB', 'MB', 'GB'];
+    let unitIndex = 0;
+    let value = bytes;
+
+    while (value >= 1024 && unitIndex < units.length - 1) {
+      value /= 1024;
+      unitIndex += 1;
+    }
+
+    if (unitIndex === 0) {
+      return `${Math.round(value)} ${units[unitIndex]}`;
+    }
+
+    return `${value.toFixed(1)} ${units[unitIndex]}`;
+  }
+
+  function updateStatus(entries: VfsRecycleBinEntry[]) {
+    if (!statusCount || !statusSize) {
+      return;
+    }
+
+    const totalBytes = entries.reduce((acc, entry) => acc + (entry.size ?? 0), 0);
+    statusCount.textContent = `${entries.length} object(s)`;
+    statusSize.textContent = formatSize(totalBytes);
+  }
+
+  function updateSelectionVisuals() {
+    if (!listHost) {
+      return;
+    }
+    let nodes: HTMLElement[] = [];
+    if (typeof listHost.querySelectorAll === 'function') {
+      nodes = Array.from(listHost.querySelectorAll<HTMLElement>('.app-recycle-bin__row'));
+    } else {
+      const rawChildren = (listHost as unknown as { children?: unknown }).children;
+      if (Array.isArray(rawChildren)) {
+        nodes = rawChildren as HTMLElement[];
+      } else if (rawChildren && typeof (rawChildren as { length: number }).length === 'number') {
+        nodes = Array.from(rawChildren as ArrayLike<HTMLElement>);
+      }
+    }
+    nodes.forEach((node) => {
+      const dataset = (node as HTMLElement & { dataset?: Record<string, string> }).dataset;
+      const id = dataset?.id ?? node.getAttribute?.('data-id') ?? null;
+      if (!id) {
+        return;
+      }
+      if (id === selectedId) {
+        if (dataset) {
+          dataset.selected = 'true';
+        }
+      } else if (dataset && Object.prototype.hasOwnProperty.call(dataset, 'selected')) {
+        delete dataset.selected;
+      }
+    });
+  }
+
+  function setSelected(id: string | null) {
+    selectedId = id;
+    updateSelectionVisuals();
+    updateActions(currentEntries);
+  }
+
+  function renderRows(entries: VfsRecycleBinEntry[]) {
+    if (!listHost || !emptyState) {
+      return;
+    }
+
+    listHost.innerHTML = '';
+
+    if (typeof emptyState.toggleAttribute === 'function') {
+      emptyState.toggleAttribute('hidden', entries.length > 0);
+    } else if ('hidden' in emptyState) {
+      (emptyState as { hidden?: boolean }).hidden = entries.length > 0;
+    } else if (entries.length > 0) {
+      emptyState.setAttribute?.('hidden', 'true');
+    } else {
+      emptyState.removeAttribute?.('hidden');
+    }
+
+    if (entries.length === 0) {
+      return;
+    }
+
+    entries.forEach((entry) => {
+      const row = document.createElement('div');
+      row.className = 'app-recycle-bin__row';
+      row.dataset.id = entry.id;
+
+      const name = document.createElement('span');
+      name.className = 'app-recycle-bin__cell app-recycle-bin__cell--name';
+      name.textContent = entry.name;
+      row.appendChild(name);
+
+      const location = document.createElement('span');
+      location.className = 'app-recycle-bin__cell app-recycle-bin__cell--location';
+      location.textContent = entry.originalPath;
+      row.appendChild(location);
+
+      const deleted = document.createElement('span');
+      deleted.className = 'app-recycle-bin__cell app-recycle-bin__cell--deleted';
+      deleted.textContent = formatDeletedAt(entry.deletedAt);
+      row.appendChild(deleted);
+
+      row.addEventListener('click', (event) => {
+        event.preventDefault();
+        setSelected(entry.id);
+      });
+
+      row.addEventListener('dblclick', () => {
+        setSelected(entry.id);
+        restoreSelected();
+      });
+
+      if (entry.id === selectedId) {
+        row.dataset.selected = 'true';
+      }
+      listHost.appendChild(row);
+    });
+  }
+
+  function restoreSelected() {
+    if (!selectedId) {
+      return;
+    }
+    try {
+      vfs.recycleBin.restore(selectedId);
+    } catch (error) {
+      console.error('Failed to restore entry from recycle bin', error);
+    }
+    selectedId = null;
+    refresh();
+  }
+
+  function emptyRecycleBin() {
+    const entries = vfs.recycleBin.list();
+    if (!entries.length) {
+      return;
+    }
+    const confirmed = typeof window !== 'undefined' ? window.confirm?.('Empty the Recycle Bin?') ?? true : true;
+    if (!confirmed) {
+      return;
+    }
+    vfs.recycleBin.empty();
+    selectedId = null;
+    refresh();
+  }
+
+  function refresh() {
+    currentEntries = getEntries();
+    if (selectedId && !currentEntries.some((entry) => entry.id === selectedId)) {
+      selectedId = null;
+    }
+    renderRows(currentEntries);
+    updateSelectionVisuals();
+    updateActions(currentEntries);
+    updateStatus(currentEntries);
+  }
+
+  function mount(host: HTMLElement) {
+    container = document.createElement('div');
+    container.className = 'app-recycle-bin';
+
+    const menuBar = document.createElement('div');
+    menuBar.className = 'app-recycle-bin__menubar';
+    ['File', 'Edit', 'View', 'Help'].forEach((label) => {
+      const menuItem = document.createElement('button');
+      menuItem.type = 'button';
+      menuItem.className = 'app-recycle-bin__menu-item';
+      menuItem.textContent = label;
+      menuItem.addEventListener('click', () => {
+        console.info(`Recycle Bin ${label} menu clicked`);
+      });
+      menuBar.appendChild(menuItem);
+    });
+    container.appendChild(menuBar);
+
+    const toolbar = document.createElement('div');
+    toolbar.className = 'app-recycle-bin__toolbar';
+    container.appendChild(toolbar);
+
+    restoreButton = document.createElement('button');
+    restoreButton.type = 'button';
+    restoreButton.className = 'app-recycle-bin__button';
+    restoreButton.textContent = 'Restore';
+    restoreButton.disabled = true;
+    restoreButton.addEventListener('click', () => restoreSelected());
+    toolbar.appendChild(restoreButton);
+
+    emptyButton = document.createElement('button');
+    emptyButton.type = 'button';
+    emptyButton.className = 'app-recycle-bin__button';
+    emptyButton.textContent = 'Empty Recycle Bin';
+    emptyButton.disabled = true;
+    emptyButton.addEventListener('click', () => emptyRecycleBin());
+    toolbar.appendChild(emptyButton);
+
+    const header = document.createElement('div');
+    header.className = 'app-recycle-bin__header';
+    header.innerHTML = `
+      <span class="app-recycle-bin__header-cell app-recycle-bin__cell--name">Name</span>
+      <span class="app-recycle-bin__header-cell app-recycle-bin__cell--location">Original Location</span>
+      <span class="app-recycle-bin__header-cell app-recycle-bin__cell--deleted">Deleted</span>
+    `;
+    container.appendChild(header);
+
+    listHost = document.createElement('div');
+    listHost.className = 'app-recycle-bin__list';
+    listHost.tabIndex = 0;
+    listHost.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        restoreSelected();
+      }
+    });
+    container.appendChild(listHost);
+
+    emptyState = document.createElement('div');
+    emptyState.className = 'app-recycle-bin__empty';
+    emptyState.textContent = 'No deleted items right now.';
+    container.appendChild(emptyState);
+
+    const statusBar = document.createElement('div');
+    statusBar.className = 'app-recycle-bin__status';
+
+    statusCount = document.createElement('span');
+    statusCount.className = 'app-recycle-bin__status-count';
+    statusBar.appendChild(statusCount);
+
+    statusSize = document.createElement('span');
+    statusSize.className = 'app-recycle-bin__status-size';
+    statusBar.appendChild(statusSize);
+
+    container.appendChild(statusBar);
+
+    host.appendChild(container);
+
+    teardown.push(
+      vfs.bus.on('vfs:recycle-bin:changed', () => refresh()),
+      vfs.bus.on('vfs:recycle-bin', () => refresh()),
+    );
+
+    refresh();
+  }
+
+  function destroy() {
+    teardown.splice(0).forEach((fn) => fn());
+    if (container) {
+      container.remove();
+    }
+    container = null;
+    listHost = null;
+    emptyState = null;
+    restoreButton = null;
+    emptyButton = null;
+    statusCount = null;
+    statusSize = null;
+    selectedId = null;
+  }
+
+  return {
+    mount,
+    destroy,
+  };
+}
+
+export type { VfsRecycleBinEntry };

--- a/win95sim_v2/src/services/vfs/index.ts
+++ b/win95sim_v2/src/services/vfs/index.ts
@@ -211,6 +211,10 @@ export function createVfsService(options: CreateVfsServiceOptions = {}): VfsServ
   const watchers: WatchBucket[] = [];
   const { bin: recycleBin, capture, restore } = createRecycleBin();
 
+  function emitRecycleBinChanged() {
+    bus.emit('vfs:recycle-bin:changed', recycleBin.list());
+  }
+
   function emit(type: VfsWatchEventType, node: InternalNode, previousPath?: string) {
     const event: VfsWatchEvent = { type, node: toPublic(node, true), previousPath };
     watchers.forEach((bucket) => {
@@ -456,6 +460,7 @@ export function createVfsService(options: CreateVfsServiceOptions = {}): VfsServ
     removeNode(normalized);
     emit('deleted', node);
     bus.emit('vfs:recycle-bin', entry);
+    emitRecycleBinChanged();
   }
 
   function watchPath(path: string, handler: (event: VfsWatchEvent) => void): () => void {
@@ -563,8 +568,15 @@ export function createVfsService(options: CreateVfsServiceOptions = {}): VfsServ
 
   const recycleBinFacade: VfsRecycleBin = {
     list: () => recycleBin.list(),
-    empty: () => recycleBin.empty(),
-    restore: (id: string) => restoreFromRecycleBin(id),
+    empty: () => {
+      recycleBin.empty();
+      emitRecycleBinChanged();
+    },
+    restore: (id: string) => {
+      const restored = restoreFromRecycleBin(id);
+      emitRecycleBinChanged();
+      return restored;
+    },
   };
 
   const service: VfsService = {

--- a/win95sim_v2/src/shell/boot/session.ts
+++ b/win95sim_v2/src/shell/boot/session.ts
@@ -12,6 +12,7 @@ import { createDesktopModule, type DesktopEntry } from '@apps/shell/desktop';
 import { createExplorerApp, type ExplorerInstance } from '@apps/explorer';
 import { createPaintApp, type PaintAppInstance } from '@apps/creative/paint';
 import { createNavigatorApp, type NavigatorAppInstance } from '@apps/internet/navigator';
+import { createRecycleBinApp, type RecycleBinAppInstance } from '@apps/system/recycle-bin';
 import { createRecentDocumentsService } from '@services/recent-documents';
 import { createCrtViewport } from '@ui/components/crtViewport';
 import { createWindowFrame } from '@ui/components/windowFrame';
@@ -55,6 +56,7 @@ const WINDOW_ICONS = {
   welcome: 'icons/w98_windows.ico',
   myComputer: 'icons/w98_computer.ico',
   recycleBin: 'icons/w98_recycle_bin_empty.ico',
+  recycleBinFull: 'icons/w98_recycle_bin_full.ico',
   internetExplorer: 'icons/w98_msie1.ico',
   paint: 'icons/w98_paint.ico',
   notepad: 'icons/w98_notepad.ico',
@@ -188,6 +190,7 @@ export function createShellSession(): ShellSession {
     resolveEntries: () => desktopEntries,
     gridSize: 48,
   });
+  let recycleBinHasItems = false;
 
   layout.setItem(DESKTOP_SURFACE_ID, 'desktop/computer', { x: 30, y: 10 }, { snapToGrid: false });
   layout.setItem(DESKTOP_SURFACE_ID, 'desktop/recycle-bin', { x: 30, y: 78 }, { snapToGrid: false });
@@ -479,12 +482,37 @@ export function createShellSession(): ShellSession {
     return viewport;
   }
 
+  function getRecycleBinIcon(): string {
+    return recycleBinHasItems ? WINDOW_ICONS.recycleBinFull : WINDOW_ICONS.recycleBin;
+  }
+
+  function syncRecycleBinIcon() {
+    const entry = desktopEntries.find((item) => item.id === 'desktop/recycle-bin');
+    recycleBinHasItems = vfs.recycleBin.list().length > 0;
+    if (!entry) {
+      return;
+    }
+    const nextIcon = getRecycleBinIcon();
+    if (entry.icon !== nextIcon) {
+      entry.icon = nextIcon;
+      if (desktopView) {
+        renderDesktop();
+      }
+    }
+  }
+
   function renderDesktop() {
     if (!desktopView) {
       return;
     }
     desktopView.render(desktopModule.list());
   }
+
+  vfs.bus.on('vfs:recycle-bin:changed', () => {
+    syncRecycleBinIcon();
+  });
+
+  syncRecycleBinIcon();
 
   function handleDesktopSelection(id: string, additive: boolean) {
     const current = new Set(desktopModule.getSelection());
@@ -872,6 +900,34 @@ export function createShellSession(): ShellSession {
     return form;
   }
 
+  function launchRecycleBinWindow(options: { id?: string; title?: string; icon?: string } = {}) {
+    let recycleBinInstance: RecycleBinAppInstance | undefined;
+    const descriptor = openWindow({
+      id: options.id ?? 'shell:window:recycle-bin',
+      title: options.title ?? 'Recycle Bin',
+      icon: options.icon ?? getRecycleBinIcon(),
+      width: 480,
+      height: 360,
+      content: () => {
+        const host = document.createElement('div');
+        recycleBinInstance = createRecycleBinApp({ vfs });
+        recycleBinInstance.mount(host);
+        return host;
+      },
+    });
+    if (recycleBinInstance) {
+      const windowId = descriptor.id;
+      const teardown = appTeardowns.get(windowId);
+      if (teardown) {
+        teardown();
+      }
+      appTeardowns.set(windowId, () => {
+        recycleBinInstance?.destroy();
+      });
+    }
+    return descriptor;
+  }
+
   function launchExplorerWindow(options: { id?: string; title?: string; startPath?: string; icon?: string } = {}) {
     let explorerInstance: ExplorerInstance | undefined;
     const descriptor = openWindow({
@@ -998,13 +1054,10 @@ export function createShellSession(): ShellSession {
         icon: WINDOW_ICONS.myComputer,
       }),
     'shell:start:recycle-bin': () =>
-      openWindow({
+      launchRecycleBinWindow({
         id: 'shell:window:recycle-bin',
         title: 'Recycle Bin',
-        icon: WINDOW_ICONS.recycleBin,
-        width: 340,
-        height: 280,
-        content: () => createPlaceholderContent('Recycle Bin', 'No deleted items to show right now.'),
+        icon: getRecycleBinIcon(),
       }),
     'shell:start:notepad': () =>
       openWindow({

--- a/win95sim_v2/src/styles/global.css
+++ b/win95sim_v2/src/styles/global.css
@@ -200,6 +200,239 @@ body {
   text-shadow: none;
 }
 
+.win95-explorer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--win95-color-window);
+  color: #000;
+}
+
+.win95-explorer__layout {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  flex: 1;
+  min-height: 0;
+}
+
+.win95-explorer__tree {
+  background: #ffffff;
+  border-right: 1px solid #808080;
+  padding: 4px;
+  overflow: auto;
+}
+
+.win95-explorer__tree-item {
+  font-size: 12px;
+  padding: 2px 4px;
+  border: 1px solid transparent;
+  cursor: default;
+  border-radius: var(--win95-radius);
+}
+
+.win95-explorer__tree-item--selected {
+  background: var(--win95-color-highlight);
+  color: var(--win95-color-highlight-text);
+  border-color: var(--win95-color-highlight-text);
+}
+
+.win95-explorer__tree-children {
+  margin-left: 12px;
+}
+
+.win95-explorer__content {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: var(--win95-color-window);
+}
+
+.win95-explorer__breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 6px;
+  background: #c0c0c0;
+  border-bottom: 1px solid #808080;
+  box-shadow: inset 0 -1px 0 #ffffff;
+}
+
+.win95-explorer__breadcrumbs button {
+  border: 1px solid #000000;
+  border-right-color: #ffffff;
+  border-bottom-color: #ffffff;
+  background: linear-gradient(180deg, #fdfdfd, #c0c0c0);
+  font-family: var(--win95-font-ui);
+  font-size: 12px;
+  padding: 2px 8px;
+  cursor: pointer;
+}
+
+.win95-explorer__breadcrumbs button:active {
+  border-top-color: #808080;
+  border-left-color: #808080;
+  border-right-color: #ffffff;
+  border-bottom-color: #ffffff;
+  background: linear-gradient(180deg, #c0c0c0, #fdfdfd);
+}
+
+.win95-explorer__details {
+  flex: 1;
+  overflow: auto;
+  padding: 6px;
+  background: #ffffff;
+  outline: none;
+}
+
+.win95-explorer__details:focus-visible {
+  outline: 1px dotted #000000;
+}
+
+.win95-explorer__details-item {
+  padding: 2px 6px;
+  margin: 2px 0;
+  border: 1px solid transparent;
+  user-select: none;
+  cursor: default;
+  font-size: 12px;
+  border-radius: var(--win95-radius);
+}
+
+.win95-explorer__details-item[data-selected='true'] {
+  background: var(--win95-color-highlight);
+  color: var(--win95-color-highlight-text);
+  border-color: var(--win95-color-highlight-text);
+}
+
+.app-recycle-bin {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--win95-color-window);
+  color: #000;
+}
+
+.app-recycle-bin__menubar {
+  display: flex;
+  gap: 6px;
+  padding: 2px 6px;
+  background: #c0c0c0;
+  border-bottom: 1px solid #808080;
+  box-shadow: inset 0 1px 0 #ffffff;
+}
+
+.app-recycle-bin__menu-item {
+  border: none;
+  background: transparent;
+  font-family: var(--win95-font-ui);
+  font-size: 12px;
+  padding: 2px 6px;
+  color: #000;
+  cursor: default;
+}
+
+.app-recycle-bin__menu-item:hover,
+.app-recycle-bin__menu-item:focus-visible {
+  background: #000080;
+  color: #ffffff;
+  outline: none;
+}
+
+.app-recycle-bin__toolbar {
+  display: flex;
+  gap: 8px;
+  padding: 6px 8px;
+  background: #c0c0c0;
+  border-bottom: 1px solid #808080;
+  box-shadow: inset 0 1px 0 #ffffff;
+}
+
+.app-recycle-bin__button {
+  min-width: 120px;
+  padding: 2px 10px;
+  border: 1px solid #000000;
+  border-right-color: #ffffff;
+  border-bottom-color: #ffffff;
+  background: linear-gradient(180deg, #fdfdfd, #c0c0c0);
+  font-family: var(--win95-font-ui);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.app-recycle-bin__button:active {
+  border-top-color: #808080;
+  border-left-color: #808080;
+  border-right-color: #ffffff;
+  border-bottom-color: #ffffff;
+  background: linear-gradient(180deg, #c0c0c0, #fdfdfd);
+}
+
+.app-recycle-bin__button:disabled {
+  color: #808080;
+  cursor: default;
+}
+
+.app-recycle-bin__header {
+  display: grid;
+  grid-template-columns: minmax(140px, 2fr) minmax(160px, 3fr) minmax(140px, 2fr);
+  gap: 4px;
+  padding: 4px 8px;
+  background: #dcdcdc;
+  border-bottom: 1px solid #808080;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.app-recycle-bin__list {
+  flex: 1;
+  overflow: auto;
+  background: #ffffff;
+}
+
+.app-recycle-bin__row {
+  display: grid;
+  grid-template-columns: minmax(140px, 2fr) minmax(160px, 3fr) minmax(140px, 2fr);
+  gap: 4px;
+  padding: 4px 8px;
+  border: 1px solid transparent;
+  border-radius: var(--win95-radius);
+  font-size: 12px;
+  cursor: default;
+}
+
+.app-recycle-bin__row[data-selected='true'] {
+  background: var(--win95-color-highlight);
+  color: var(--win95-color-highlight-text);
+  border-color: var(--win95-color-highlight-text);
+}
+
+.app-recycle-bin__cell--name {
+  font-weight: 600;
+}
+
+.app-recycle-bin__empty {
+  padding: 24px;
+  text-align: center;
+  font-size: 13px;
+  color: #404040;
+}
+
+.app-recycle-bin__status {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 4px 8px;
+  background: #c0c0c0;
+  border-top: 1px solid #808080;
+  box-shadow: inset 0 1px 0 #ffffff;
+  font-size: 12px;
+}
+
+.app-recycle-bin__status-count,
+.app-recycle-bin__status-size {
+  white-space: nowrap;
+}
+
 .window-frame {
   position: absolute;
   display: flex;


### PR DESCRIPTION
## Summary
- add a Win95-style menu bar and status footer to the recycle bin app with live counts and size totals
- extend shared styles to cover the recycle bin menus/status and document the app surface for integrators
- bump build metadata after rebuilding the distribution bundle

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fd3f8fe2a48329960e5e2ae63822e7