### PR TITLE
Fix MS-DOS prompt window flush styling

### DIFF
--- a/win95sim_v2/src/apps/system/msdos/index.ts
+++ b/win95sim_v2/src/apps/system/msdos/index.ts
@@ -231,6 +231,74 @@ export function createMsDosPromptApp({ vfs, onExit }: MsDosPromptDependencies): 
   let promptTemplate = environment.get('PROMPT') ?? DEFAULT_PROMPT_TEMPLATE;
   let echoEnabled = true;
   let mountedHost: HTMLElement | undefined;
+  let cleanupWindowBodyPadding: (() => void) | undefined;
+
+  function addClassName(element: HTMLElement, className: string) {
+    const classList = element.classList as DOMTokenList | undefined;
+    if (classList && typeof classList.add === 'function') {
+      classList.add(className);
+      return;
+    }
+    const existing = typeof element.className === 'string'
+      ? element.className.split(/\s+/).filter((token) => token.length > 0)
+      : [];
+    if (!existing.includes(className)) {
+      existing.push(className);
+    }
+    element.className = existing.join(' ');
+  }
+
+  function removeClassName(element: HTMLElement, className: string) {
+    const classList = element.classList as DOMTokenList | undefined;
+    if (classList && typeof classList.remove === 'function') {
+      classList.remove(className);
+      return;
+    }
+    if (typeof element.className !== 'string') {
+      return;
+    }
+    const filtered = element.className
+      .split(/\s+/)
+      .filter((token) => token.length > 0 && token !== className);
+    element.className = filtered.join(' ');
+  }
+
+  function applyWindowBodyFlush(host: HTMLElement) {
+    queueMicrotask(() => {
+      if (mountedHost !== host) {
+        return;
+      }
+
+      let current: HTMLElement | null = host;
+      let windowBody: HTMLElement | null = null;
+      while (current) {
+        const hasClassList = current.classList?.contains?.('window-body');
+        const hasClassName = typeof current.className === 'string'
+          && current.className.split(/\s+/).includes('window-body');
+        if (hasClassList || hasClassName) {
+          windowBody = current;
+          break;
+        }
+        current = current.parentElement;
+      }
+
+      if (!windowBody) {
+        return;
+      }
+
+      if (cleanupWindowBodyPadding) {
+        cleanupWindowBodyPadding();
+      }
+
+      cleanupWindowBodyPadding = () => {
+        if (!windowBody) {
+          return;
+        }
+        removeClassName(windowBody, 'window-body--flush');
+      };
+      addClassName(windowBody, 'window-body--flush');
+    });
+  }
 
   function formatPrompt(): string {
     const drive = parts(cwd).drive;
@@ -844,15 +912,23 @@ export function createMsDosPromptApp({ vfs, onExit }: MsDosPromptDependencies): 
     if (mountedHost === host) {
       return;
     }
+    cleanupWindowBodyPadding?.();
+    if (mountedHost) {
+      removeClassName(mountedHost, 'app-msdos__host');
+    }
     mountedHost = host;
     host.innerHTML = '';
+    addClassName(host, 'app-msdos__host');
     host.appendChild(container);
+    applyWindowBodyFlush(host);
     resetScreen();
     updatePrompt();
     inputField.focus();
   }
 
   function destroy() {
+    cleanupWindowBodyPadding?.();
+    cleanupWindowBodyPadding = undefined;
     if (typeof inputForm.removeEventListener === 'function') {
       inputForm.removeEventListener('submit', submitHandler);
     }
@@ -861,6 +937,9 @@ export function createMsDosPromptApp({ vfs, onExit }: MsDosPromptDependencies): 
     }
     if (container.parentElement) {
       container.parentElement.removeChild(container);
+    }
+    if (mountedHost) {
+      removeClassName(mountedHost, 'app-msdos__host');
     }
     mountedHost = undefined;
   }

--- a/win95sim_v2/src/styles/global.css
+++ b/win95sim_v2/src/styles/global.css
@@ -610,6 +610,10 @@ body {
   overflow: auto;
 }
 
+.window-body--flush {
+  padding: 0;
+}
+
 .window-content {
   flex: 1 1 auto;
   display: flex;
@@ -1178,23 +1182,40 @@ body {
   resize: none;
 }
 
+
 .app-msdos {
   display: flex;
   flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
   height: 100%;
   background: #000000;
   color: #c0c0c0;
   font-family: 'Lucida Console', monospace;
   font-size: 14px;
-  padding: 6px;
-  box-sizing: border-box;
+}
+
+.app-msdos__host {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
+  height: 100%;
+  background: #000000;
+  overflow: hidden;
 }
 
 .app-msdos__output {
-  flex: 1;
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
+  overflow-x: auto;
   white-space: pre;
-  margin-bottom: 6px;
+  padding: 12px 12px 0;
+  margin: 0;
+  box-sizing: border-box;
 }
 
 .app-msdos__line {
@@ -1206,6 +1227,9 @@ body {
   display: flex;
   align-items: center;
   gap: 6px;
+  padding: 12px;
+  padding-top: 6px;
+  box-sizing: border-box;
 }
 
 .app-msdos__prompt {


### PR DESCRIPTION
## Summary
- ensure the MS-DOS prompt host adds and removes classes safely in the test harness while forcing the window body flush behavior
- update the MS-DOS prompt layout styles so the terminal background fills the window frame without grey gutters while preserving internal padding for content

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fec3c814dc83299ad46f9b296883ff