### PR TITLE
Add VFS file associations and connect Explorer file open actions

### DIFF
--- a/win95sim_v2/build-info.json
+++ b/win95sim_v2/build-info.json
@@ -1,4 +1,4 @@
 {
-  "lastCommit": "210a3b3bd25ab3e9455ccecf540cd54ed38c25b0",
-  "buildNumber": 5
+  "lastCommit": "304eced9cc47d46278d83e555c2bc253c84edb95",
+  "buildNumber": 6
 }

--- a/win95sim_v2/docs/explorer-integration.md
+++ b/win95sim_v2/docs/explorer-integration.md
@@ -14,6 +14,9 @@ teams integrating with the new modules.
   - Recycle bin APIs exposed through `service.recycleBin` with `list`,
     `restore`, and `empty` helpers.
   - Shortcut resolution using `resolveShortcut(path)`.
+  - File association registry (`registerFileAssociation`,
+    `getFileAssociation`, `listFileAssociations`) for wiring extensions to
+    application handlers.
   - Event bus (`service.bus`) emitting `vfs:*` events for cross-service
     listeners.
 
@@ -23,9 +26,11 @@ Paths are normalised (`C:/Folder/File.txt`) and drives are case insensitive.
 ## Explorer app
 - Declared via `src/apps/explorer/explorer.app.json` so the process service can
   discover and spawn Explorer windows.
-- Runtime entry point `createExplorerApp({ vfs, startPath })` renders tree and
+- Runtime entry point `createExplorerApp({ vfs, startPath, onOpenNode })` renders tree and
   details panes. The app listens to VFS watchers so desktop icons and other apps
   can share the same service instance without refreshing the view manually.
+- Optional `onOpenNode` callback fires when users double-click a file in the
+  details pane so the shell can delegate to associated applications.
 - Breadcrumb navigation emits `setPath` calls that downstream tooling can hook
   into for automation or testing.
 

--- a/win95sim_v2/docs/module-apis-v2.md
+++ b/win95sim_v2/docs/module-apis-v2.md
@@ -127,6 +127,18 @@ interface FileSystemService {
   write(path: string, contents: Uint8Array | string): Promise<void>;
   list(path: string): Promise<FileNode[]>;
   watch(path: string, handler: (event: FileEvent) => void): () => void;
+  registerFileAssociation(
+    extension: string,
+    association: { appId: string; command?: string },
+  ): FileAssociation;
+  getFileAssociation(path: string): FileAssociation | undefined;
+  listFileAssociations(): FileAssociation[];
+}
+
+interface FileAssociation {
+  extension: string;
+  appId: string;
+  command?: string;
 }
 ```
 

--- a/win95sim_v2/src/apps/creative/paint/index.ts
+++ b/win95sim_v2/src/apps/creative/paint/index.ts
@@ -24,6 +24,7 @@ export interface PaintAppOptions {
 export interface PaintAppInstance {
   mount(host: HTMLElement): void;
   destroy(): void;
+  openDocument(path: string): Promise<void>;
 }
 
 const DEFAULT_WIDTH = 480;
@@ -661,6 +662,33 @@ export function createPaintApp(options: PaintAppOptions = {}): PaintAppInstance 
     }
   }
 
+  async function openDocumentFromPath(path: string, options: { confirm?: boolean } = {}): Promise<void> {
+    if (!vfs) {
+      setStatus('File system integration is unavailable.');
+      throw new Error('File system integration is unavailable.');
+    }
+    if (options.confirm !== false && !confirmDiscard()) {
+      return;
+    }
+    try {
+      const node = await vfs.read(path);
+      if (node.kind !== 'file') {
+        throw new Error('Selected item is not a paint document.');
+      }
+      const snapshot = decodeSnapshot(node.content);
+      currentFilePath = node.path;
+      loadSnapshot(snapshot);
+      setStatus(`Opened ${describeDocument(currentFilePath)}`);
+    } catch (error) {
+      if (error instanceof Error) {
+        setStatus(`Open failed: ${error.message}`);
+        throw error;
+      }
+      setStatus('Open failed.');
+      throw new Error('Open failed.');
+    }
+  }
+
   async function handleOpenDocument(): Promise<void> {
     if (!vfs) {
       setStatus('File system integration is unavailable.');
@@ -674,22 +702,7 @@ export function createPaintApp(options: PaintAppOptions = {}): PaintAppInstance 
     if (!selected) {
       return;
     }
-    try {
-      const node = await vfs.read(selected);
-      if (node.kind !== 'file') {
-        throw new Error('Selected item is not a paint document.');
-      }
-      const snapshot = decodeSnapshot(node.content);
-      currentFilePath = normalizePath(selected);
-      loadSnapshot(snapshot);
-      setStatus(`Opened ${describeDocument(currentFilePath)}`);
-    } catch (error) {
-      if (error instanceof Error) {
-        setStatus(`Open failed: ${error.message}`);
-      } else {
-        setStatus('Open failed.');
-      }
-    }
+    await openDocumentFromPath(selected, { confirm: false }).catch(() => undefined);
   }
 
   function handleNewDocument() {
@@ -1261,6 +1274,9 @@ export function createPaintApp(options: PaintAppOptions = {}): PaintAppInstance 
       markClean();
       setStatus('Brush ready');
       bindGlobalShortcuts();
+    },
+    async openDocument(path: string) {
+      await openDocumentFromPath(path);
     },
     destroy() {
       closeMenu();

--- a/win95sim_v2/src/apps/explorer/index.ts
+++ b/win95sim_v2/src/apps/explorer/index.ts
@@ -9,6 +9,7 @@ interface ExplorerTreeNode {
 export interface ExplorerOptions {
   vfs: VfsService;
   startPath?: string;
+  onOpenNode?: (node: VfsNode) => void;
 }
 
 export interface ExplorerInstance {
@@ -222,6 +223,10 @@ export function createExplorerApp(options: ExplorerOptions): ExplorerInstance {
     if (entry.kind === 'directory') {
       item.addEventListener('dblclick', () => {
         void setPath(entry.path);
+      });
+    } else if (entry.kind === 'file') {
+      item.addEventListener('dblclick', () => {
+        options.onOpenNode?.(entry);
       });
     }
     return item;

--- a/win95sim_v2/src/services/vfs/index.ts
+++ b/win95sim_v2/src/services/vfs/index.ts
@@ -6,6 +6,8 @@ import { lookupIcon } from './utils/icons';
 import type {
   CreateVfsServiceOptions,
   VfsDirectoryNode,
+  VfsFileAssociation,
+  VfsFileAssociationSeed,
   VfsFileNode,
   VfsNode,
   VfsRecycleBin,
@@ -42,6 +44,23 @@ interface WatchBucket {
 }
 
 const DEFAULT_DRIVES = ['C:/'];
+
+function normalizeExtension(extension: string): string {
+  const trimmed = extension.trim();
+  if (!trimmed) {
+    throw new Error('Extension cannot be empty');
+  }
+  const normalized = trimmed.startsWith('.') ? trimmed.toLowerCase() : `.${trimmed.toLowerCase()}`;
+  return normalized;
+}
+
+function extractExtension(path: string): string | undefined {
+  const match = /\.([^.]+)$/.exec(path.toLowerCase());
+  if (!match) {
+    return undefined;
+  }
+  return `.${match[1]}`;
+}
 
 function now(): number {
   return Date.now();
@@ -210,6 +229,7 @@ export function createVfsService(options: CreateVfsServiceOptions = {}): VfsServ
   const nodes = new Map<string, InternalNode>();
   const watchers: WatchBucket[] = [];
   const { bin: recycleBin, capture, restore } = createRecycleBin();
+  const fileAssociations = new Map<string, VfsFileAssociation>();
 
   function emitRecycleBinChanged() {
     bus.emit('vfs:recycle-bin:changed', recycleBin.list());
@@ -562,6 +582,13 @@ export function createVfsService(options: CreateVfsServiceOptions = {}): VfsServ
         void createShortcut(seed.path, seed.target, undefined);
       }
     });
+
+    options.associations?.forEach((association: VfsFileAssociationSeed) => {
+      registerFileAssociation(association.extension, {
+        appId: association.appId,
+        command: association.command,
+      });
+    });
   }
 
   bootstrap();
@@ -593,6 +620,37 @@ export function createVfsService(options: CreateVfsServiceOptions = {}): VfsServ
     search,
     resolveShortcut,
     recycleBin: recycleBinFacade,
+    registerFileAssociation(extension, association) {
+      const normalized = normalizeExtension(extension);
+      const record: VfsFileAssociation = {
+        extension: normalized,
+        appId: association.appId,
+        command: association.command,
+      };
+      fileAssociations.set(normalized, record);
+      return { ...record };
+    },
+    unregisterFileAssociation(extension) {
+      const normalized = normalizeExtension(extension);
+      fileAssociations.delete(normalized);
+    },
+    getFileAssociation(path) {
+      let normalizedPath: string;
+      try {
+        normalizedPath = normalizePath(path);
+      } catch {
+        normalizedPath = path.replace(/\\/g, '/');
+      }
+      const extension = extractExtension(normalizedPath);
+      if (!extension) {
+        return undefined;
+      }
+      const record = fileAssociations.get(extension);
+      return record ? { ...record } : undefined;
+    },
+    listFileAssociations() {
+      return Array.from(fileAssociations.values()).map((entry) => ({ ...entry }));
+    },
     bus,
   };
 

--- a/win95sim_v2/src/services/vfs/types.ts
+++ b/win95sim_v2/src/services/vfs/types.ts
@@ -84,6 +84,20 @@ export interface VfsRecycleBin {
 export interface CreateVfsServiceOptions {
   /** Optional seed tree used by tests/fixtures. */
   seed?: Array<{ path: string; kind: VfsNodeKind; content?: string | Uint8Array; target?: string }>;
+  /** Optional file association seed table applied during bootstrap. */
+  associations?: VfsFileAssociationSeed[];
+}
+
+export interface VfsFileAssociationSeed {
+  extension: string;
+  appId: string;
+  command?: string;
+}
+
+export interface VfsFileAssociation {
+  extension: string;
+  appId: string;
+  command?: string;
 }
 
 export interface VfsService {
@@ -98,5 +112,9 @@ export interface VfsService {
   search(query: string, options?: VfsSearchOptions): Promise<VfsNode[]>;
   resolveShortcut(path: string): Promise<VfsNode>;
   recycleBin: VfsRecycleBin;
+  registerFileAssociation(extension: string, association: Omit<VfsFileAssociation, 'extension'>): VfsFileAssociation;
+  unregisterFileAssociation(extension: string): void;
+  getFileAssociation(path: string): VfsFileAssociation | undefined;
+  listFileAssociations(): VfsFileAssociation[];
   bus: EventBus;
 }

--- a/win95sim_v2/src/services/vfs/utils/mime.ts
+++ b/win95sim_v2/src/services/vfs/utils/mime.ts
@@ -10,6 +10,7 @@ const MIME_TABLE = new Map<string, { mime: string; icon: string }>([
   ['wav', { mime: 'audio/wav', icon: 'audio' }],
   ['mp3', { mime: 'audio/mpeg', icon: 'audio' }],
   ['lnk', { mime: 'application/x-ms-shortcut', icon: 'shortcut' }],
+  ['w95p', { mime: 'application/x-win95paint', icon: 'image' }],
 ]);
 
 const DEFAULT_ENTRY = { mime: 'application/octet-stream', icon: 'file' };

--- a/win95sim_v2/src/shell/boot/session.ts
+++ b/win95sim_v2/src/shell/boot/session.ts
@@ -24,7 +24,7 @@ import { createWindowFrame } from '@ui/components/windowFrame';
 import { createTaskbarView } from '@ui/components/taskbar';
 import { createStartMenuView } from '@ui/components/startMenu';
 import { createDesktopView, type DesktopDragEvent } from '@ui/components/desktopIcons';
-import { createVfsService } from '@services/vfs';
+import { createVfsService, type VfsNode } from '@services/vfs';
 import { createWindowInteractionController } from '@features/window-interactions';
 import { createMsDosPromptApp, type MsDosPromptInstance } from '@apps/system/msdos';
 import { createPrintService } from '@services/print';
@@ -189,6 +189,9 @@ export function createShellSession(): ShellSession {
   const dialogState = createDialogStateService();
   const print = createPrintService();
   const vfs = createVfsService({ seed: DEFAULT_VFS_SEED });
+  vfs.registerFileAssociation('.txt', { appId: 'apps/notepad' });
+  vfs.registerFileAssociation('.log', { appId: 'apps/notepad' });
+  vfs.registerFileAssociation('.w95p', { appId: 'apps/paint' });
   const recentDocuments = createRecentDocumentsService();
   const startMenuModel = createStartMenuModel({ recentDocuments });
   const taskbar = createTaskbarController({ windows, bus });
@@ -232,6 +235,7 @@ export function createShellSession(): ShellSession {
   const pendingContent = new Map<string, HTMLElement>();
   const appTeardowns = new Map<string, () => void>();
   const notepadWindows = new Map<string, NotepadWindowInstance>();
+  const paintWindows = new Map<string, PaintAppInstance>();
 
   let viewport: ReturnType<typeof createCrtViewport> | undefined;
   let workspace: HTMLElement | undefined;
@@ -849,7 +853,7 @@ export function createShellSession(): ShellSession {
     return container;
   }
 
-  function createNotepadContent(windowId: string): HTMLElement {
+  function createNotepadContent(windowId: string, initialPath?: string): HTMLElement {
     const appInstance = createNotepadApp({ settings, dialogState, print });
     const instance = createNotepadWindow({
       app: appInstance,
@@ -867,6 +871,11 @@ export function createShellSession(): ShellSession {
       },
     });
     notepadWindows.set(windowId, instance);
+    if (initialPath) {
+      void instance
+        .openPath(initialPath)
+        .catch((error) => console.error('Failed to open document in Notepad', error));
+    }
     return instance.element;
   }
 
@@ -919,6 +928,30 @@ export function createShellSession(): ShellSession {
     form.appendChild(actions);
 
     return form;
+  }
+
+  function launchNotepadWindow(options: { id?: string; title?: string; icon?: string; path?: string } = {}) {
+    const windowId = options.id ?? `app:notepad:${windowSequence++}`;
+    const descriptor = openWindow({
+      id: windowId,
+      title: options.title ?? 'Notepad',
+      icon: options.icon ?? WINDOW_ICONS.notepad,
+      width: 520,
+      height: 340,
+      content: () => createNotepadContent(windowId, options.path),
+    });
+    const teardown = appTeardowns.get(descriptor.id);
+    if (teardown) {
+      teardown();
+    }
+    appTeardowns.set(descriptor.id, () => {
+      const instance = notepadWindows.get(descriptor.id);
+      if (instance) {
+        instance.dispose();
+        notepadWindows.delete(descriptor.id);
+      }
+    });
+    return descriptor;
   }
 
   function launchRecycleBinWindow(options: { id?: string; title?: string; icon?: string } = {}) {
@@ -990,6 +1023,9 @@ export function createShellSession(): ShellSession {
         explorerInstance = createExplorerApp({
           vfs,
           startPath: options.startPath ?? DEFAULT_EXPLORER_HOME,
+          onOpenNode: (node) => {
+            void openFileWithAssociation(node.path);
+          },
         });
         explorerInstance.mount(host);
         return host;
@@ -1008,10 +1044,11 @@ export function createShellSession(): ShellSession {
     return descriptor;
   }
 
-  function launchPaintWindow(options: { id?: string; title?: string; icon?: string } = {}) {
+  function launchPaintWindow(options: { id?: string; title?: string; icon?: string; documentPath?: string } = {}) {
+    const windowId = options.id ?? `app:paint:${windowSequence++}`;
     let paintInstance: PaintAppInstance | undefined;
     const descriptor = openWindow({
-      id: options.id,
+      id: windowId,
       title: options.title ?? 'Paint',
       icon: options.icon ?? WINDOW_ICONS.paint,
       width: 620,
@@ -1029,16 +1066,94 @@ export function createShellSession(): ShellSession {
       },
     });
     if (paintInstance) {
-      const windowId = descriptor.id;
-      const teardown = appTeardowns.get(windowId);
+      paintWindows.set(descriptor.id, paintInstance);
+      const teardown = appTeardowns.get(descriptor.id);
       if (teardown) {
         teardown();
       }
-      appTeardowns.set(windowId, () => {
-        paintInstance?.destroy();
+      appTeardowns.set(descriptor.id, () => {
+        const instance = paintWindows.get(descriptor.id);
+        if (instance) {
+          instance.destroy();
+          paintWindows.delete(descriptor.id);
+        }
       });
+      if (options.documentPath) {
+        void paintInstance
+          .openDocument(options.documentPath)
+          .catch((error) => console.error('Failed to open document in Paint', error));
+      }
     }
     return descriptor;
+  }
+
+  async function openFileWithAssociation(path: string): Promise<void> {
+    let node: VfsNode;
+    try {
+      node = await vfs.read(path);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      openWindow({
+        title: 'Win95Sim',
+        icon: WINDOW_ICONS.defaultApp,
+        width: 360,
+        height: 220,
+        content: () =>
+          createPlaceholderContent('Unable to open file', `Win95Sim could not open "${path}" (${message}).`),
+      });
+      return;
+    }
+
+    if (node.kind === 'directory') {
+      launchExplorerWindow({
+        title: node.name,
+        startPath: node.path,
+        icon: WINDOW_ICONS.explorer,
+      });
+      return;
+    }
+
+    if (node.kind !== 'file') {
+      return;
+    }
+
+    const association = vfs.getFileAssociation(node.path);
+    if (!association) {
+      openWindow({
+        title: node.name,
+        icon: WINDOW_ICONS.defaultApp,
+        width: 360,
+        height: 220,
+        content: () =>
+          createPlaceholderContent(
+            node.name,
+            `Win95Sim doesn't know how to open "${node.name}" yet.`,
+          ),
+      });
+      return;
+    }
+
+    switch (association.appId) {
+      case 'apps/notepad':
+        launchNotepadWindow({ path: node.path });
+        break;
+      case 'apps/paint':
+        launchPaintWindow({ documentPath: node.path, title: node.name });
+        break;
+      default:
+        openWindow({
+          title: node.name,
+          icon: WINDOW_ICONS.defaultApp,
+          width: 360,
+          height: 220,
+          content: () =>
+            createPlaceholderContent(
+              node.name,
+              `Application "${association.appId}" is not available in this build.`,
+            ),
+        });
+        break;
+    }
   }
 
   function launchMsDosPromptWindow(options: { id?: string; title?: string; icon?: string } = {}) {
@@ -1144,29 +1259,7 @@ export function createShellSession(): ShellSession {
         title: 'Recycle Bin',
         icon: getRecycleBinIcon(),
       }),
-    'shell:start:notepad': () => {
-      const id = `app:notepad:${windowSequence++}`;
-      const descriptor = openWindow({
-        id,
-        title: 'Notepad',
-        icon: WINDOW_ICONS.notepad,
-        width: 520,
-        height: 340,
-        content: () => createNotepadContent(id),
-      });
-      const teardown = appTeardowns.get(descriptor.id);
-      if (teardown) {
-        teardown();
-      }
-      appTeardowns.set(descriptor.id, () => {
-        const instance = notepadWindows.get(descriptor.id);
-        if (instance) {
-          instance.dispose();
-          notepadWindows.delete(descriptor.id);
-        }
-      });
-      return descriptor;
-    },
+    'shell:start:notepad': () => launchNotepadWindow(),
     'shell:start:paint': () =>
       launchPaintWindow({
         id: `app:paint:${windowSequence}`,
@@ -1299,14 +1392,7 @@ export function createShellSession(): ShellSession {
       const recentId = command.slice('shell:open:recent:'.length);
       const entry = recentDocuments.list().find((item) => item.id === recentId);
       if (entry) {
-        openWindow({
-          title: entry.title,
-          icon: WINDOW_ICONS.documents,
-          width: 420,
-          height: 260,
-          content: () =>
-            createPlaceholderContent(entry.title, `Win95Sim cannot open "${entry.path}" yet, but it's on the roadmap.`),
-        });
+        void openFileWithAssociation(entry.path);
         if (shouldCloseStartMenu) {
           closeStartMenu();
         }

--- a/win95sim_v2/tests/phase02-filesystem.test.js
+++ b/win95sim_v2/tests/phase02-filesystem.test.js
@@ -59,6 +59,21 @@ test('filesystem service supports CRUD, watchers, search, and recycle bin', asyn
   assert.ok(events.some((event) => event.type === 'moved' && event.previousPath === 'C:/Projects/Archive'));
 });
 
+test('filesystem service exposes file association helpers', () => {
+  const { createVfsService } = loadModule('src/services/vfs/index.ts');
+  const vfs = createVfsService();
+  const registered = vfs.registerFileAssociation('.txt', { appId: 'apps/notepad', command: 'shell:start:notepad' });
+  assert.equal(registered.extension, '.txt');
+  assert.equal(registered.appId, 'apps/notepad');
+  const resolved = vfs.getFileAssociation('C:/Docs/Readme.TXT');
+  assert.ok(resolved, 'expected association to resolve for mixed case extension');
+  assert.equal(resolved.appId, 'apps/notepad');
+  const list = vfs.listFileAssociations();
+  assert.equal(list.length, 1);
+  vfs.unregisterFileAssociation('.txt');
+  assert.equal(vfs.getFileAssociation('C:/Docs/Readme.txt'), undefined);
+});
+
 function extractTreeLabels(node) {
   const labels = [];
   node.children.forEach((child) => {
@@ -121,6 +136,40 @@ test('explorer app renders tree and details panes reacting to VFS updates', asyn
     assert.ok(directoriesAfter.includes('Assets'));
     const updatedTreeLabels = extractTreeLabels(treePane);
     assert.ok(updatedTreeLabels.includes('Assets'));
+
+    explorer.destroy();
+  });
+});
+
+test('explorer double-click dispatches file open callback', async () => {
+  const { createVfsService } = loadModule('src/services/vfs/index.ts');
+  const { createExplorerApp } = loadModule('src/apps/explorer/index.ts');
+  const vfs = createVfsService({ seed: sampleTree() });
+  await vfs.writeFile('C:/Projects/Test.txt', 'content');
+
+  await withFakeDom(async () => {
+    const opened = [];
+    const host = document.createElement('div');
+    const explorer = createExplorerApp({
+      vfs,
+      startPath: 'C:/Projects',
+      onOpenNode: (node) => opened.push(node.path),
+    });
+    explorer.mount(host);
+
+    await flush();
+    await flush();
+
+    const container = host.children[0];
+    const layout = container.children[0];
+    const content = layout.children[1];
+    const detailsPane = content.children[1];
+    const items = Array.from(detailsPane.children);
+    const target = items.find((child) => child.dataset?.path === 'C:/Projects/Test.txt');
+    assert.ok(target, 'expected Test.txt item in details pane');
+    target.dispatchEvent('dblclick');
+
+    assert.deepEqual(opened, ['C:/Projects/Test.txt']);
 
     explorer.destroy();
   });

--- a/win95sim_v2/tests/phase03-shell.test.js
+++ b/win95sim_v2/tests/phase03-shell.test.js
@@ -503,6 +503,10 @@ test('double-clicking desktop shortcuts launches core applications', () => {
               host.dataset.app = 'paint';
             }
           },
+          openDocument(path) {
+            this.openedPath = path;
+            return Promise.resolve();
+          },
           destroy() {
             this.destroyed = true;
           },


### PR DESCRIPTION
## Summary
- add a file association registry to the VFS and expose it through the Explorer API
- teach the shell to launch Notepad and Paint when double-clicking associated files and allow Paint to open documents
- document the new interfaces and extend automated coverage for associations and Explorer callbacks

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fec51e988c832991b2c88d0b121cf8