### PR TITLE
Restore classic Minesweeper chrome

### DIFF
--- a/win95sim_v2/build-info.json
+++ b/win95sim_v2/build-info.json
@@ -1,4 +1,4 @@
 {
-  "lastCommit": "210a3b3bd25ab3e9455ccecf540cd54ed38c25b0",
-  "buildNumber": 5
+  "lastCommit": "38d35e1342d088e71c8dde63dc9f62800610db2a",
+  "buildNumber": 7
 }

--- a/win95sim_v2/src/apps/games/minesweeper/index.ts
+++ b/win95sim_v2/src/apps/games/minesweeper/index.ts
@@ -70,13 +70,13 @@ export function createMinesweeperApp(options: MinesweeperAppOptions = {}): Mines
 
   let host: HTMLElement | null = null;
   let container: HTMLElement | null = null;
-  let toolbar: HTMLDivElement | null = null;
+  let menuBar: HTMLDivElement | null = null;
   let controls: HTMLDivElement | null = null;
   let difficultySelect: HTMLSelectElement | null = null;
   let newGameButton: HTMLButtonElement | null = null;
   let statusPanel: HTMLDivElement | null = null;
   let minesCounter: HTMLSpanElement | null = null;
-  let statusIndicator: HTMLSpanElement | null = null;
+  let statusIndicator: HTMLButtonElement | null = null;
   let timerCounter: HTMLSpanElement | null = null;
   let boardWrapper: HTMLDivElement | null = null;
   let boardElement: HTMLDivElement | null = null;
@@ -214,15 +214,23 @@ export function createMinesweeperApp(options: MinesweeperAppOptions = {}): Mines
     minesCounter.setAttribute('aria-label', `Mines remaining: ${remainingMines}`);
 
     const statusFaces: Record<MinesweeperState['status'], string> = {
-      ready: '🙂 Ready',
-      'in-progress': '😮 In progress',
-      won: '😎 You win!',
-      lost: '😵 Boom!',
+      ready: '🙂',
+      'in-progress': '😮',
+      won: '😎',
+      lost: '😵',
+    };
+
+    const statusLabels: Record<MinesweeperState['status'], string> = {
+      ready: 'Ready for a new game',
+      'in-progress': 'Game in progress',
+      won: 'Game won',
+      lost: 'Game lost',
     };
 
     statusIndicator.textContent = statusFaces[state.status];
     statusIndicator.dataset.state = state.status;
-    statusIndicator.setAttribute('aria-label', statusFaces[state.status]);
+    statusIndicator.setAttribute('aria-label', statusLabels[state.status]);
+    statusIndicator.title = statusLabels[state.status];
 
     switch (state.status) {
       case 'ready':
@@ -334,13 +342,26 @@ export function createMinesweeperApp(options: MinesweeperAppOptions = {}): Mines
     container = document.createElement('div');
     container.className = 'app-minesweeper';
 
-    toolbar = document.createElement('div');
-    toolbar.className = 'app-minesweeper__toolbar';
-    container.appendChild(toolbar);
+    menuBar = document.createElement('div');
+    menuBar.className = 'app-minesweeper__menubar';
+    menuBar.setAttribute('role', 'menubar');
+
+    const gameMenuItem = document.createElement('button');
+    gameMenuItem.type = 'button';
+    gameMenuItem.className = 'app-minesweeper__menu-item';
+    gameMenuItem.textContent = 'Game';
+    gameMenuItem.setAttribute('role', 'menuitem');
+    menuBar.appendChild(gameMenuItem);
+
+    const helpMenuItem = document.createElement('button');
+    helpMenuItem.type = 'button';
+    helpMenuItem.className = 'app-minesweeper__menu-item';
+    helpMenuItem.textContent = 'Help';
+    helpMenuItem.setAttribute('role', 'menuitem');
+    menuBar.appendChild(helpMenuItem);
 
     controls = document.createElement('div');
     controls.className = 'app-minesweeper__controls';
-    toolbar.appendChild(controls);
 
     const difficultyLabel = document.createElement('label');
     difficultyLabel.className = 'app-minesweeper__label';
@@ -367,6 +388,9 @@ export function createMinesweeperApp(options: MinesweeperAppOptions = {}): Mines
     controls.appendChild(difficultyLabel);
     controls.appendChild(newGameButton);
 
+    boardWrapper = document.createElement('div');
+    boardWrapper.className = 'app-minesweeper__board-wrapper';
+
     statusPanel = document.createElement('div');
     statusPanel.className = 'app-minesweeper__status';
 
@@ -375,21 +399,21 @@ export function createMinesweeperApp(options: MinesweeperAppOptions = {}): Mines
     minesCounter.setAttribute('aria-live', 'polite');
     statusPanel.appendChild(minesCounter);
 
-    statusIndicator = document.createElement('span');
+    statusIndicator = document.createElement('button');
+    statusIndicator.type = 'button';
     statusIndicator.className = 'app-minesweeper__indicator';
-    statusIndicator.setAttribute('role', 'status');
     statusIndicator.setAttribute('aria-live', 'polite');
     statusPanel.appendChild(statusIndicator);
+
+    statusIndicator.addEventListener('click', handleNewGame);
+    cleanupListeners.push(() => statusIndicator?.removeEventListener('click', handleNewGame));
 
     timerCounter = document.createElement('span');
     timerCounter.className = 'app-minesweeper__counter';
     timerCounter.setAttribute('aria-live', 'polite');
     statusPanel.appendChild(timerCounter);
 
-    toolbar.appendChild(statusPanel);
-
-    boardWrapper = document.createElement('div');
-    boardWrapper.className = 'app-minesweeper__board-wrapper';
+    boardWrapper.appendChild(statusPanel);
 
     boardElement = document.createElement('div');
     boardElement.className = 'app-minesweeper__board';
@@ -397,7 +421,10 @@ export function createMinesweeperApp(options: MinesweeperAppOptions = {}): Mines
     boardElement.setAttribute('aria-label', 'Minesweeper board');
     boardWrapper.appendChild(boardElement);
 
+    container.appendChild(menuBar);
     container.appendChild(boardWrapper);
+
+    container.appendChild(controls);
 
     difficultySelect?.addEventListener('change', handleDifficultyChange);
     cleanupListeners.push(() => difficultySelect?.removeEventListener('change', handleDifficultyChange));
@@ -431,7 +458,7 @@ export function createMinesweeperApp(options: MinesweeperAppOptions = {}): Mines
 
     host = null;
     container = null;
-    toolbar = null;
+    menuBar = null;
     controls = null;
     difficultySelect = null;
     newGameButton = null;

--- a/win95sim_v2/src/shell/boot/session.ts
+++ b/win95sim_v2/src/shell/boot/session.ts
@@ -955,8 +955,8 @@ export function createShellSession(): ShellSession {
       id: options.id,
       title: options.title ?? 'Minesweeper',
       icon: options.icon ?? WINDOW_ICONS.minesweeper,
-      width: 820,
-      height: 620,
+      width: 360,
+      height: 380,
       content: () => {
         const host = document.createElement('div');
         minesweeperInstance = createMinesweeperApp();

--- a/win95sim_v2/src/styles/global.css
+++ b/win95sim_v2/src/styles/global.css
@@ -892,32 +892,62 @@ body {
 }
 
 .app-minesweeper {
-  display: flex;
+  display: inline-flex;
   flex-direction: column;
-  gap: 8px;
-  height: 100%;
+  align-items: stretch;
+  gap: 4px;
+  padding: 6px;
   background: var(--win95-color-window);
+  box-sizing: border-box;
 }
 
-.app-minesweeper__toolbar {
+.app-minesweeper__menubar {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
-  padding: 4px 6px;
+  gap: 6px;
+  padding: 2px 6px 3px;
   background: #c0c0c0;
-  border: 1px solid #808080;
-  box-shadow:
-    inset 0 1px 0 #ffffff,
-    inset 0 -1px 0 #ffffff;
+  border: 1px solid #ffffff;
+  border-bottom-color: #808080;
+  box-shadow: inset 0 1px 0 #ffffff;
+}
+
+.app-minesweeper__menu-item {
+  font-family: var(--win95-font-ui);
+  font-size: 12px;
+  padding: 1px 6px;
+  border: none;
+  background: transparent;
+  color: #000000;
+  cursor: default;
+  user-select: none;
+}
+
+.app-minesweeper__menu-item:focus-visible {
+  outline: 1px dotted #000000;
+  outline-offset: -1px;
+}
+
+.app-minesweeper__menu-item:active {
+  background: #000080;
+  color: #ffffff;
 }
 
 .app-minesweeper__controls {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 8px;
   flex-wrap: wrap;
+  padding: 4px 10px;
+  background: #c0c0c0;
+  border: 2px solid #808080;
+  border-top-color: #ffffff;
+  border-left-color: #ffffff;
+  box-shadow:
+    inset -1px -1px 0 #404040,
+    inset 1px 1px 0 #ffffff;
+  align-self: stretch;
 }
 
 .app-minesweeper__label {
@@ -925,6 +955,7 @@ body {
   align-items: center;
   gap: 4px;
   font-size: 12px;
+  flex: 1 1 auto;
 }
 
 .app-minesweeper__select {
@@ -956,51 +987,116 @@ body {
 .app-minesweeper__status {
   display: flex;
   align-items: center;
-  gap: 16px;
-  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 8px;
+  background: #c0c0c0;
+  border: 2px solid #808080;
+  border-top-color: #ffffff;
+  border-left-color: #ffffff;
   font-size: 12px;
+  box-shadow:
+    inset -1px -1px 0 #404040,
+    inset 1px 1px 0 #ffffff;
 }
 
 .app-minesweeper__counter {
   display: inline-flex;
   align-items: center;
   justify-content: flex-end;
-  min-width: 54px;
+  min-width: 60px;
   padding: 2px 6px;
-  border: 2px inset #808080;
+  border: 2px solid #404040;
+  border-top-color: #808080;
+  border-left-color: #808080;
+  border-right-color: #000000;
+  border-bottom-color: #000000;
   background: #000000;
-  color: #ff0000;
-  font-family: 'Lucida Console', monospace;
-  font-size: 14px;
+  color: #ff1a1a;
+  font-family:
+    'Digital-7',
+    'DS-Digital',
+    'Quartz MS',
+    'Quartz',
+    'Segment7',
+    'Seven Segment',
+    'Digital Readout Upright',
+    'Digital Readout Thick Upright',
+    'Courier New',
+    monospace;
+  font-size: 22px;
   line-height: 1;
-  letter-spacing: 1px;
+  letter-spacing: 2px;
+  text-shadow:
+    0 0 3px rgba(255, 0, 0, 0.4),
+    0 0 6px rgba(255, 0, 0, 0.2);
 }
 
 .app-minesweeper__indicator {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 132px;
-  padding: 2px 8px;
-  border: 2px groove #808080;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 2px solid #808080;
+  border-top-color: #ffffff;
+  border-left-color: #ffffff;
+  border-right-color: #404040;
+  border-bottom-color: #404040;
   background: #c0c0c0;
-  font-size: 12px;
-  font-weight: 600;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow:
+    inset -1px -1px 0 #808080,
+    inset 1px 1px 0 #ffffff;
+  margin: 0 auto;
+}
+
+.app-minesweeper__indicator:active {
+  border-top-color: #404040;
+  border-left-color: #404040;
+  border-right-color: #ffffff;
+  border-bottom-color: #ffffff;
+  box-shadow:
+    inset 1px 1px 0 #808080,
+    inset -1px -1px 0 #ffffff;
 }
 
 .app-minesweeper__board-wrapper {
-  flex: 1 1 auto;
+  align-self: center;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 6px;
+  max-width: 100%;
   overflow: auto;
   padding: 6px;
-  border: 2px solid #c0c0c0;
-  background: #808080;
+  border: 2px solid #808080;
+  border-top-color: #ffffff;
+  border-left-color: #ffffff;
+  border-right-color: #404040;
+  border-bottom-color: #404040;
+  background: #c0c0c0;
+  box-shadow:
+    inset 1px 1px 0 #c0c0c0,
+    inset -1px -1px 0 #808080;
+  box-sizing: border-box;
 }
 
 .app-minesweeper__board {
   display: grid;
-  gap: 2px;
+  gap: 1px;
   justify-content: start;
   grid-auto-rows: 24px;
+  padding: 3px;
+  background: #808080;
+  border: 2px solid #808080;
+  border-right-color: #ffffff;
+  border-bottom-color: #ffffff;
+  box-shadow:
+    inset 1px 1px 0 #404040,
+    inset -1px -1px 0 #ffffff;
 }
 
 .app-minesweeper__cell {

--- a/win95sim_v2/tests/phase07-games.test.js
+++ b/win95sim_v2/tests/phase07-games.test.js
@@ -117,15 +117,28 @@ test('minesweeper app mounts board, controls, and cleans up', () => {
       return undefined;
     };
 
-    const toolbar = findByClass(root, 'app-minesweeper__toolbar');
+    const menuBar = findByClass(root, 'app-minesweeper__menubar');
+    const status = findByClass(root, 'app-minesweeper__status');
     const board = findByClass(root, 'app-minesweeper__board');
+    const controlsPanel = findByClass(root, 'app-minesweeper__controls');
     const select = findByClass(root, 'app-minesweeper__select');
     const button = findByClass(root, 'app-minesweeper__button');
+    const indicator = findByClass(root, 'app-minesweeper__indicator');
 
-    assert.ok(toolbar, 'expected toolbar to render');
+    assert.ok(menuBar, 'expected menu bar to render');
+    assert.deepEqual(
+      Array.from(menuBar?.children ?? []).map((child) => child.textContent?.trim()),
+      ['Game', 'Help'],
+      'expected Game and Help menu entries',
+    );
+    assert.ok(status, 'expected status panel to render');
+    assert.ok(status?.parentElement?.className.includes('app-minesweeper__board-wrapper'), 'status should sit inside board frame');
     assert.ok(board, 'expected board to render');
+    assert.ok(controlsPanel, 'expected controls panel to render');
     assert.ok(select, 'expected difficulty selector');
     assert.ok(button, 'expected new game button');
+    assert.equal(indicator?.tagName, 'BUTTON', 'status indicator should be a button');
+    assert.equal(indicator?.textContent?.trim(), '🙂', 'status indicator should show ready face');
     assert.ok(board.children.length > 0, 'expected board to contain cells');
 
     app.destroy();


### PR DESCRIPTION
## Summary
- add a Game/Help menubar and smiley reset button to the Minesweeper app while tightening status messaging
- refresh Minesweeper styles to recreate the Win95 digital counters and bezel treatment
- extend the phase 07 Minesweeper test to cover the new menu bar and indicator

## Testing
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fec44645588329b7f26e0c05a0daae