### PR TITLE
Fix Windows Help icons and widen default windows

### DIFF
--- a/win95sim_v2/docs/shell-commands.md
+++ b/win95sim_v2/docs/shell-commands.md
@@ -13,7 +13,7 @@ Phase 03 introduces a small set of shell command identifiers that are consumed b
 | `shell:start:control-panel` | Open the Control Panel surface. |
 | `shell:start:taskbar-settings` | Open the Taskbar & Start Menu settings panel. |
 | `shell:start:find-files` | Trigger the Find Files dialog. |
-| `shell:start:help` | Open the Windows Help viewer with its classic menu, toolbar, tree-based contents, Index, and Find tabs. |
+| `shell:start:help` | Open the Windows Help viewer with its classic menu, toolbar, tree-based contents, Index, and Find tabs. The window now launches with the Start menu help icon and a wider 640×480 default size for easier reading. |
 | `shell:start:run` | Focus the Run command dialog. |
 | `shell:start:shutdown` | Begin the system shutdown workflow. |
 

--- a/win95sim_v2/src/apps/system/help/index.ts
+++ b/win95sim_v2/src/apps/system/help/index.ts
@@ -42,6 +42,19 @@ interface HelpSearchOption {
   description: string;
 }
 
+function resolveIconPath(icon?: string): string | undefined {
+  if (!icon) {
+    return undefined;
+  }
+  if (icon.startsWith('assets/')) {
+    return icon;
+  }
+  if (icon.startsWith('/')) {
+    return `assets${icon}`;
+  }
+  return `assets/${icon}`;
+}
+
 const CONTENT_TREE: HelpContentNode[] = [
   {
     type: 'book',
@@ -413,10 +426,9 @@ export function createWindowsHelpApp(options: WindowsHelpAppOptions = {}): Windo
       splitIntoParagraphs(detailsBody, body);
     }
     if (detailsIcon) {
-      if (icon) {
-        detailsIcon.src = icon;
-      }
-      detailsIcon.hidden = !icon;
+      const resolvedIcon = resolveIconPath(icon);
+      detailsIcon.src = resolvedIcon ?? '';
+      detailsIcon.hidden = !resolvedIcon;
     }
   }
 
@@ -449,10 +461,10 @@ export function createWindowsHelpApp(options: WindowsHelpAppOptions = {}): Windo
     references.toggle.className = shouldExpand ? 'app-help__tree-toggle app-help__tree-toggle--expanded' : 'app-help__tree-toggle';
     if (shouldExpand) {
       references.children.removeAttribute('hidden');
-      references.icon.src = references.node.iconOpen;
+      references.icon.src = resolveIconPath(references.node.iconOpen) ?? '';
     } else {
       references.children.setAttribute('hidden', '');
-      references.icon.src = references.node.iconClosed;
+      references.icon.src = resolveIconPath(references.node.iconClosed) ?? '';
     }
   }
 
@@ -646,7 +658,7 @@ export function createWindowsHelpApp(options: WindowsHelpAppOptions = {}): Windo
 
       const icon = document.createElement('img');
       icon.className = 'app-help__toolbar-icon';
-      icon.src = definition.icon;
+      icon.src = resolveIconPath(definition.icon) ?? '';
       icon.alt = '';
 
       const label = document.createElement('span');
@@ -693,7 +705,7 @@ export function createWindowsHelpApp(options: WindowsHelpAppOptions = {}): Windo
 
         const icon = document.createElement('img');
         icon.className = 'app-help__tree-icon';
-        icon.src = expanded ? node.iconOpen : node.iconClosed;
+        icon.src = resolveIconPath(expanded ? node.iconOpen : node.iconClosed) ?? '';
         icon.alt = '';
 
         const label = document.createElement('button');
@@ -737,7 +749,7 @@ export function createWindowsHelpApp(options: WindowsHelpAppOptions = {}): Windo
 
         const icon = document.createElement('img');
         icon.className = 'app-help__tree-topic-icon';
-        icon.src = node.icon;
+        icon.src = resolveIconPath(node.icon) ?? '';
         icon.alt = '';
 
         button.textContent = node.title;

--- a/win95sim_v2/src/shell/boot/session.ts
+++ b/win95sim_v2/src/shell/boot/session.ts
@@ -51,8 +51,8 @@ interface ShellWindowOptions {
   content?: WindowContentSource;
 }
 
-const DEFAULT_WINDOW_WIDTH = 360;
-const DEFAULT_WINDOW_HEIGHT = 260;
+const DEFAULT_WINDOW_WIDTH = 520;
+const DEFAULT_WINDOW_HEIGHT = 400;
 const WINDOW_CASCADE_STEP = 24;
 const DESKTOP_SURFACE_ID = '::desktop';
 const DEFAULT_EXPLORER_HOME = 'C:/';
@@ -75,7 +75,7 @@ const WINDOW_ICONS = {
   controlPanel: 'icons/w98_directory_control_panel.ico',
   taskbar: 'icons/w2k_taskbar.ico',
   findFiles: 'icons/w2k_search.ico',
-  help: 'icons/w98_help_book_cool.ico',
+  help: 'icons/w2k_help.ico',
   run: 'icons/w2k_run.ico',
   startup: 'icons/w2k_folder_open.ico',
   shutdown: 'icons/w2k_shutdown.ico',
@@ -1321,8 +1321,8 @@ export function createShellSession(): ShellSession {
       const descriptor = openWindow({
         title: 'Windows Help',
         icon: WINDOW_ICONS.help,
-        width: 460,
-        height: 360,
+        width: 640,
+        height: 480,
         content: () => {
           const host = document.createElement('div');
           helpInstance = createWindowsHelpApp({

--- a/win95sim_v2/tests/phase03-shell.test.js
+++ b/win95sim_v2/tests/phase03-shell.test.js
@@ -238,6 +238,18 @@ test('windows help app renders tabbed viewer with default content', () => {
     const actionLabels = collectByClass('app-help__action-button').map((button) => button.textContent?.trim());
     assert.deepEqual(actionLabels, ['Display', 'Print...', 'Cancel']);
 
+    const toolbarIcons = collectByClass('app-help__toolbar-icon').map((img) => img.src);
+    toolbarIcons.forEach((src) => {
+      assert.ok(src && src.startsWith('assets/icons/'), `expected toolbar icon to resolve to assets/icons/, received ${src}`);
+    });
+
+    const viewerIcon = collectByClass('app-help__viewer-icon')[0];
+    assert.ok(viewerIcon);
+    assert.ok(
+      viewerIcon.src && viewerIcon.src.startsWith('assets/icons/'),
+      'expected viewer icon to use bundled asset path',
+    );
+
     app.destroy();
     assert.equal(host.children.length, 0);
   });


### PR DESCRIPTION
## Summary
- resolve Windows Help icons through a shared helper so toolbar, tree, and viewer assets are bundled correctly and reuse the Start menu help icon
- increase the shell default window size and launch Windows Help at 640×480 to match the wider baseline layout
- extend the Windows Help regression test to verify asset paths and document the updated launch behaviour in the shell command reference

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fecf358a848329a7d9d97b27db382a