### PR TITLE
Refine Minesweeper menubar layout

### DIFF
--- a/win95sim_v2/build-info.json
+++ b/win95sim_v2/build-info.json
@@ -1,4 +1,4 @@
 {
-  "lastCommit": "210a3b3bd25ab3e9455ccecf540cd54ed38c25b0",
-  "buildNumber": 5
+  "lastCommit": "ff0fffdd536f4296874c7e9ab44d871a52137d3c",
+  "buildNumber": 8
 }

--- a/win95sim_v2/src/apps/games/minesweeper/index.ts
+++ b/win95sim_v2/src/apps/games/minesweeper/index.ts
@@ -70,16 +70,20 @@ export function createMinesweeperApp(options: MinesweeperAppOptions = {}): Mines
 
   let host: HTMLElement | null = null;
   let container: HTMLElement | null = null;
-  let toolbar: HTMLDivElement | null = null;
-  let controls: HTMLDivElement | null = null;
-  let difficultySelect: HTMLSelectElement | null = null;
-  let newGameButton: HTMLButtonElement | null = null;
+  let menuBar: HTMLDivElement | null = null;
+  let gameMenuRoot: HTMLDivElement | null = null;
+  let gameMenuButton: HTMLButtonElement | null = null;
+  let gameMenu: HTMLDivElement | null = null;
+  let helpMenuButton: HTMLButtonElement | null = null;
   let statusPanel: HTMLDivElement | null = null;
   let minesCounter: HTMLSpanElement | null = null;
-  let statusIndicator: HTMLSpanElement | null = null;
+  let statusIndicator: HTMLButtonElement | null = null;
   let timerCounter: HTMLSpanElement | null = null;
   let boardWrapper: HTMLDivElement | null = null;
   let boardElement: HTMLDivElement | null = null;
+
+  const difficultyMenuItems = new Map<MinesweeperDifficulty, HTMLButtonElement>();
+  let openMenu: 'game' | null = null;
 
   let timerHandle: ReturnType<typeof setInterval> | undefined;
   let timerStartedAt: number | null = null;
@@ -214,15 +218,23 @@ export function createMinesweeperApp(options: MinesweeperAppOptions = {}): Mines
     minesCounter.setAttribute('aria-label', `Mines remaining: ${remainingMines}`);
 
     const statusFaces: Record<MinesweeperState['status'], string> = {
-      ready: '🙂 Ready',
-      'in-progress': '😮 In progress',
-      won: '😎 You win!',
-      lost: '😵 Boom!',
+      ready: '🙂',
+      'in-progress': '😮',
+      won: '😎',
+      lost: '😵',
+    };
+
+    const statusLabels: Record<MinesweeperState['status'], string> = {
+      ready: 'Ready for a new game',
+      'in-progress': 'Game in progress',
+      won: 'Game won',
+      lost: 'Game lost',
     };
 
     statusIndicator.textContent = statusFaces[state.status];
     statusIndicator.dataset.state = state.status;
-    statusIndicator.setAttribute('aria-label', statusFaces[state.status]);
+    statusIndicator.setAttribute('aria-label', statusLabels[state.status]);
+    statusIndicator.title = statusLabels[state.status];
 
     switch (state.status) {
       case 'ready':
@@ -241,14 +253,153 @@ export function createMinesweeperApp(options: MinesweeperAppOptions = {}): Mines
     }
   }
 
-  function render(state: MinesweeperState) {
-    if (difficultySelect) {
-      const presetExists = presetList.some((preset) => preset.id === state.difficulty);
-      difficultySelect.value = presetExists ? state.difficulty : activePreset.id;
+  function updateDifficultyMenuSelection(state: MinesweeperState) {
+    if (difficultyMenuItems.size === 0) {
+      return;
     }
 
+    const active = difficultyMenuItems.has(state.difficulty)
+      ? state.difficulty
+      : activePreset.id;
+
+    difficultyMenuItems.forEach((item, difficulty) => {
+      const isActive = difficulty === active;
+      const activeValue = isActive ? 'true' : 'false';
+      if (item.dataset) {
+        item.dataset.active = activeValue;
+      }
+      item.setAttribute('data-active', activeValue);
+      item.setAttribute('aria-checked', activeValue);
+    });
+  }
+
+  function closeMenus() {
+    openMenu = null;
+    if (gameMenuButton) {
+      gameMenuButton.setAttribute('aria-expanded', 'false');
+    }
+    if (gameMenu) {
+      if (gameMenu.classList && typeof gameMenu.classList.remove === 'function') {
+        gameMenu.classList.remove('app-minesweeper__menu--open');
+      } else if (typeof gameMenu.className === 'string') {
+        gameMenu.className = gameMenu.className
+          .split(/\s+/)
+          .filter((token) => token && token !== 'app-minesweeper__menu--open')
+          .join(' ');
+      }
+    }
+  }
+
+  function focusFirstMenuItem() {
+    if (!gameMenu) {
+      return;
+    }
+    const firstItem = gameMenu.querySelector<HTMLButtonElement>('.app-minesweeper__menu-option');
+    if (firstItem && typeof firstItem.focus === 'function') {
+      firstItem.focus();
+    }
+  }
+
+  function openGameMenu() {
+    if (!gameMenuButton || !gameMenu) {
+      return;
+    }
+    openMenu = 'game';
+    gameMenuButton.setAttribute('aria-expanded', 'true');
+    if (gameMenu.classList && typeof gameMenu.classList.add === 'function') {
+      gameMenu.classList.add('app-minesweeper__menu--open');
+    } else if (typeof gameMenu.className === 'string') {
+      const tokens = new Set(gameMenu.className.split(/\s+/).filter(Boolean));
+      tokens.add('app-minesweeper__menu--open');
+      gameMenu.className = Array.from(tokens).join(' ');
+    }
+  }
+
+  function toggleGameMenu(event?: Event) {
+    event?.preventDefault();
+    event?.stopPropagation();
+    if (openMenu === 'game') {
+      closeMenus();
+      gameMenuButton?.focus();
+    } else {
+      openGameMenu();
+      focusFirstMenuItem();
+    }
+  }
+
+  function handleDocumentClick(event: MouseEvent) {
+    if (openMenu !== 'game') {
+      return;
+    }
+    const target = event.target as Node | null;
+    if (!target) {
+      closeMenus();
+      return;
+    }
+    if (gameMenuRoot?.contains(target)) {
+      return;
+    }
+    closeMenus();
+  }
+
+  function handleDocumentKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Escape' && openMenu === 'game') {
+      closeMenus();
+      gameMenuButton?.focus();
+    }
+  }
+
+  function handleGameMenuButtonKeyDown(event: KeyboardEvent) {
+    if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      if (openMenu !== 'game') {
+        openGameMenu();
+      }
+      focusFirstMenuItem();
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (openMenu !== 'game') {
+        openGameMenu();
+      }
+      if (gameMenu) {
+        const items = gameMenu.querySelectorAll<HTMLButtonElement>('.app-minesweeper__menu-option');
+        const last = items[items.length - 1];
+        last?.focus?.();
+      }
+    }
+  }
+
+  function handleMenuOptionKeyDown(event: KeyboardEvent) {
+    if (!gameMenu || !gameMenuButton) {
+      return;
+    }
+
+    const items = Array.from(gameMenu.querySelectorAll<HTMLButtonElement>('.app-minesweeper__menu-option'));
+    if (items.length === 0) {
+      return;
+    }
+
+    const current = event.currentTarget as HTMLButtonElement | null;
+    const currentIndex = items.findIndex((item) => item === current);
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      const next = items[(currentIndex + 1) % items.length];
+      next?.focus?.();
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      const previous = items[(currentIndex - 1 + items.length) % items.length];
+      previous?.focus?.();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      closeMenus();
+      gameMenuButton.focus();
+    }
+  }
+
+  function render(state: MinesweeperState) {
     updateStatus(state);
     renderBoard(state);
+    updateDifficultyMenuSelection(state);
     updateTimerDisplay();
   }
 
@@ -307,14 +458,6 @@ export function createMinesweeperApp(options: MinesweeperAppOptions = {}): Mines
     updateState(nextState);
   };
 
-  const handleDifficultyChange = () => {
-    if (!difficultySelect) {
-      return;
-    }
-    const value = difficultySelect.value as MinesweeperDifficulty;
-    selectPreset(value);
-  };
-
   function clearHost() {
     if (host && container && container.parentElement === host) {
       host.removeChild(container);
@@ -334,38 +477,119 @@ export function createMinesweeperApp(options: MinesweeperAppOptions = {}): Mines
     container = document.createElement('div');
     container.className = 'app-minesweeper';
 
-    toolbar = document.createElement('div');
-    toolbar.className = 'app-minesweeper__toolbar';
-    container.appendChild(toolbar);
+    menuBar = document.createElement('div');
+    menuBar.className = 'app-minesweeper__menubar';
+    menuBar.setAttribute('role', 'menubar');
 
-    controls = document.createElement('div');
-    controls.className = 'app-minesweeper__controls';
-    toolbar.appendChild(controls);
+    difficultyMenuItems.clear();
 
-    const difficultyLabel = document.createElement('label');
-    difficultyLabel.className = 'app-minesweeper__label';
-    difficultyLabel.textContent = 'Difficulty:';
+    gameMenuRoot = document.createElement('div');
+    gameMenuRoot.className = 'app-minesweeper__menu-root';
 
-    difficultySelect = document.createElement('select');
-    difficultySelect.className = 'app-minesweeper__select';
+    gameMenuButton = document.createElement('button');
+    gameMenuButton.type = 'button';
+    gameMenuButton.className = 'app-minesweeper__menu-item';
+    gameMenuButton.textContent = 'Game';
+    gameMenuButton.setAttribute('role', 'menuitem');
+    gameMenuButton.setAttribute('aria-haspopup', 'true');
+    gameMenuButton.setAttribute('aria-expanded', 'false');
+    gameMenuRoot.appendChild(gameMenuButton);
+
+    gameMenu = document.createElement('div');
+    gameMenu.className = 'app-minesweeper__menu';
+    gameMenu.setAttribute('role', 'menu');
+    gameMenuRoot.appendChild(gameMenu);
+
+    const createMenuOption = (
+      label: string,
+      onSelect: () => void,
+      options: { accelerator?: string; type?: 'radio'; difficulty?: MinesweeperDifficulty } = {},
+    ) => {
+      if (!gameMenu) {
+        return;
+      }
+
+      const option = document.createElement('button');
+      option.type = 'button';
+      option.className = 'app-minesweeper__menu-option';
+      option.setAttribute('role', options.type === 'radio' ? 'menuitemradio' : 'menuitem');
+      option.textContent = '';
+
+      const labelSpan = document.createElement('span');
+      labelSpan.className = 'app-minesweeper__menu-option-label';
+      labelSpan.textContent = label;
+      option.appendChild(labelSpan);
+
+      if (options.accelerator) {
+        const accelerator = document.createElement('span');
+        accelerator.className = 'app-minesweeper__menu-option-accelerator';
+        accelerator.textContent = options.accelerator;
+        option.appendChild(accelerator);
+      }
+
+      if (options.type === 'radio') {
+        if (option.dataset) {
+          option.dataset.role = 'radio';
+          option.dataset.active = 'false';
+        }
+        option.setAttribute('data-role', 'radio');
+        option.setAttribute('data-active', 'false');
+        option.setAttribute('aria-checked', 'false');
+      }
+
+      if (options.difficulty) {
+        if (option.dataset) {
+          option.dataset.difficulty = options.difficulty;
+        }
+        option.setAttribute('data-difficulty', options.difficulty);
+        difficultyMenuItems.set(options.difficulty, option);
+      }
+
+      const handleClick = (event: MouseEvent) => {
+        event.preventDefault();
+        onSelect();
+        closeMenus();
+      };
+
+      option.addEventListener('click', handleClick);
+      option.addEventListener('keydown', handleMenuOptionKeyDown);
+
+      cleanupListeners.push(() => {
+        option.removeEventListener('click', handleClick);
+        option.removeEventListener('keydown', handleMenuOptionKeyDown);
+      });
+
+      gameMenu.appendChild(option);
+    };
+
+    const addMenuSeparator = () => {
+      if (!gameMenu) {
+        return;
+      }
+      const separator = document.createElement('div');
+      separator.className = 'app-minesweeper__menu-separator';
+      gameMenu.appendChild(separator);
+    };
+
+    createMenuOption('New', handleNewGame, { accelerator: 'F2' });
+    addMenuSeparator();
     presetList.forEach((preset) => {
-      const option = document.createElement('option');
-      option.value = preset.id;
-      option.textContent = preset.label;
-      difficultySelect?.appendChild(option);
+      createMenuOption(preset.label, () => {
+        selectPreset(preset.id);
+      }, { type: 'radio', difficulty: preset.id });
     });
-    if (difficultySelect) {
-      difficultySelect.value = activePreset.id;
-      difficultyLabel.appendChild(difficultySelect);
-    }
 
-    newGameButton = document.createElement('button');
-    newGameButton.type = 'button';
-    newGameButton.className = 'app-minesweeper__button';
-    newGameButton.textContent = 'New Game';
+    menuBar.appendChild(gameMenuRoot);
 
-    controls.appendChild(difficultyLabel);
-    controls.appendChild(newGameButton);
+    helpMenuButton = document.createElement('button');
+    helpMenuButton.type = 'button';
+    helpMenuButton.className = 'app-minesweeper__menu-item';
+    helpMenuButton.textContent = 'Help';
+    helpMenuButton.setAttribute('role', 'menuitem');
+    menuBar.appendChild(helpMenuButton);
+
+    boardWrapper = document.createElement('div');
+    boardWrapper.className = 'app-minesweeper__board-wrapper';
 
     statusPanel = document.createElement('div');
     statusPanel.className = 'app-minesweeper__status';
@@ -375,21 +599,21 @@ export function createMinesweeperApp(options: MinesweeperAppOptions = {}): Mines
     minesCounter.setAttribute('aria-live', 'polite');
     statusPanel.appendChild(minesCounter);
 
-    statusIndicator = document.createElement('span');
+    statusIndicator = document.createElement('button');
+    statusIndicator.type = 'button';
     statusIndicator.className = 'app-minesweeper__indicator';
-    statusIndicator.setAttribute('role', 'status');
     statusIndicator.setAttribute('aria-live', 'polite');
     statusPanel.appendChild(statusIndicator);
+
+    statusIndicator.addEventListener('click', handleNewGame);
+    cleanupListeners.push(() => statusIndicator?.removeEventListener('click', handleNewGame));
 
     timerCounter = document.createElement('span');
     timerCounter.className = 'app-minesweeper__counter';
     timerCounter.setAttribute('aria-live', 'polite');
     statusPanel.appendChild(timerCounter);
 
-    toolbar.appendChild(statusPanel);
-
-    boardWrapper = document.createElement('div');
-    boardWrapper.className = 'app-minesweeper__board-wrapper';
+    boardWrapper.appendChild(statusPanel);
 
     boardElement = document.createElement('div');
     boardElement.className = 'app-minesweeper__board';
@@ -397,13 +621,33 @@ export function createMinesweeperApp(options: MinesweeperAppOptions = {}): Mines
     boardElement.setAttribute('aria-label', 'Minesweeper board');
     boardWrapper.appendChild(boardElement);
 
+    container.appendChild(menuBar);
     container.appendChild(boardWrapper);
 
-    difficultySelect?.addEventListener('change', handleDifficultyChange);
-    cleanupListeners.push(() => difficultySelect?.removeEventListener('change', handleDifficultyChange));
+    const doc = container.ownerDocument ?? document;
 
-    newGameButton.addEventListener('click', handleNewGame);
-    cleanupListeners.push(() => newGameButton?.removeEventListener('click', handleNewGame));
+    if (gameMenuButton) {
+      const handleClick = (event: MouseEvent) => {
+        toggleGameMenu(event);
+      };
+      const handleKeyDown = (event: KeyboardEvent) => {
+        handleGameMenuButtonKeyDown(event);
+      };
+      gameMenuButton.addEventListener('click', handleClick);
+      gameMenuButton.addEventListener('keydown', handleKeyDown);
+      cleanupListeners.push(() => {
+        gameMenuButton?.removeEventListener('click', handleClick);
+        gameMenuButton?.removeEventListener('keydown', handleKeyDown);
+      });
+    }
+
+    if (doc && typeof doc.addEventListener === 'function' && typeof doc.removeEventListener === 'function') {
+      doc.addEventListener('click', handleDocumentClick);
+      cleanupListeners.push(() => doc.removeEventListener('click', handleDocumentClick));
+
+      doc.addEventListener('keydown', handleDocumentKeyDown);
+      cleanupListeners.push(() => doc.removeEventListener('keydown', handleDocumentKeyDown));
+    }
 
     boardElement.addEventListener('click', handleCellClick);
     cleanupListeners.push(() => boardElement?.removeEventListener('click', handleCellClick));
@@ -429,12 +673,16 @@ export function createMinesweeperApp(options: MinesweeperAppOptions = {}): Mines
 
     clearHost();
 
+    closeMenus();
+    difficultyMenuItems.clear();
+
     host = null;
     container = null;
-    toolbar = null;
-    controls = null;
-    difficultySelect = null;
-    newGameButton = null;
+    menuBar = null;
+    gameMenuRoot = null;
+    gameMenuButton = null;
+    gameMenu = null;
+    helpMenuButton = null;
     statusPanel = null;
     minesCounter = null;
     statusIndicator = null;

--- a/win95sim_v2/src/shell/boot/session.ts
+++ b/win95sim_v2/src/shell/boot/session.ts
@@ -955,8 +955,8 @@ export function createShellSession(): ShellSession {
       id: options.id,
       title: options.title ?? 'Minesweeper',
       icon: options.icon ?? WINDOW_ICONS.minesweeper,
-      width: 820,
-      height: 620,
+      width: 280,
+      height: 340,
       content: () => {
         const host = document.createElement('div');
         minesweeperInstance = createMinesweeperApp();

--- a/win95sim_v2/src/styles/global.css
+++ b/win95sim_v2/src/styles/global.css
@@ -892,115 +892,245 @@ body {
 }
 
 .app-minesweeper {
-  display: flex;
+  display: inline-flex;
   flex-direction: column;
-  gap: 8px;
-  height: 100%;
+  align-items: center;
+  gap: 2px;
+  padding: 6px;
   background: var(--win95-color-window);
+  box-sizing: border-box;
 }
 
-.app-minesweeper__toolbar {
+.app-minesweeper__menubar {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
-  padding: 4px 6px;
+  gap: 6px;
+  padding: 2px 6px 3px;
   background: #c0c0c0;
-  border: 1px solid #808080;
-  box-shadow:
-    inset 0 1px 0 #ffffff,
-    inset 0 -1px 0 #ffffff;
+  border: 1px solid #ffffff;
+  border-bottom-color: #808080;
+  box-shadow: inset 0 1px 0 #ffffff;
+  align-self: stretch;
 }
 
-.app-minesweeper__controls {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.app-minesweeper__label {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 12px;
-}
-
-.app-minesweeper__select {
+.app-minesweeper__menu-item {
   font-family: var(--win95-font-ui);
   font-size: 12px;
-  padding: 2px 4px;
-  border: 1px solid #808080;
-  background: #ffffff;
+  padding: 1px 6px;
+  border: none;
+  background: transparent;
+  color: #000000;
+  cursor: default;
+  user-select: none;
 }
 
-.app-minesweeper__button {
-  font-family: var(--win95-font-ui);
-  font-size: 12px;
-  padding: 2px 10px;
-  border: 1px solid #808080;
+.app-minesweeper__menu-item:focus-visible {
+  outline: 1px dotted #000000;
+  outline-offset: -1px;
+}
+
+.app-minesweeper__menu-item:active {
+  background: #000080;
+  color: #ffffff;
+}
+
+.app-minesweeper__menu-root {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+}
+
+.app-minesweeper__menu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 2px;
+  min-width: 152px;
+  padding: 2px 0;
   background: #c0c0c0;
+  border: 2px solid #808080;
+  border-top-color: #ffffff;
+  border-left-color: #ffffff;
   box-shadow:
-    inset -1px -1px 0 #000000,
+    2px 2px 0 #000000,
+    inset -1px -1px 0 #404040,
     inset 1px 1px 0 #ffffff;
+  z-index: 10;
+}
+
+.app-minesweeper__menu--open {
+  display: block;
+}
+
+.app-minesweeper__menu-option {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding: 2px 18px 2px 24px;
+  border: none;
+  background: transparent;
+  color: #000000;
+  font-family: var(--win95-font-ui);
+  font-size: 12px;
+  text-align: left;
   cursor: default;
 }
 
-.app-minesweeper__button:active {
-  box-shadow:
-    inset 1px 1px 0 #000000,
-    inset -1px -1px 0 #ffffff;
+.app-minesweeper__menu-option:hover,
+.app-minesweeper__menu-option:focus {
+  background: #000080;
+  color: #ffffff;
+}
+
+.app-minesweeper__menu-option[data-role='radio']::before {
+  content: '\2713';
+  position: absolute;
+  left: 6px;
+  color: transparent;
+  pointer-events: none;
+}
+
+.app-minesweeper__menu-option[data-role='radio'][data-active='true']::before {
+  color: #000000;
+}
+
+.app-minesweeper__menu-option[data-role='radio'][data-active='true']:hover::before,
+.app-minesweeper__menu-option[data-role='radio'][data-active='true']:focus::before {
+  color: currentColor;
+}
+
+.app-minesweeper__menu-option-label {
+  flex: 1;
+}
+
+.app-minesweeper__menu-option-accelerator {
+  color: #404040;
+}
+
+.app-minesweeper__menu-separator {
+  height: 1px;
+  margin: 3px 4px;
+  background: #808080;
+  box-shadow: 0 1px 0 #ffffff;
 }
 
 .app-minesweeper__status {
   display: flex;
   align-items: center;
-  gap: 16px;
-  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 8px;
+  background: #c0c0c0;
+  border: 2px solid #808080;
+  border-top-color: #ffffff;
+  border-left-color: #ffffff;
   font-size: 12px;
+  box-shadow:
+    inset -1px -1px 0 #404040,
+    inset 1px 1px 0 #ffffff;
 }
 
 .app-minesweeper__counter {
   display: inline-flex;
   align-items: center;
   justify-content: flex-end;
-  min-width: 54px;
+  min-width: 60px;
   padding: 2px 6px;
-  border: 2px inset #808080;
+  border: 2px solid #404040;
+  border-top-color: #808080;
+  border-left-color: #808080;
+  border-right-color: #000000;
+  border-bottom-color: #000000;
   background: #000000;
-  color: #ff0000;
-  font-family: 'Lucida Console', monospace;
-  font-size: 14px;
+  color: #ff1a1a;
+  font-family:
+    'Digital-7',
+    'DS-Digital',
+    'Quartz MS',
+    'Quartz',
+    'Segment7',
+    'Seven Segment',
+    'Digital Readout Upright',
+    'Digital Readout Thick Upright',
+    'Courier New',
+    monospace;
+  font-size: 22px;
   line-height: 1;
-  letter-spacing: 1px;
+  letter-spacing: 2px;
+  text-shadow:
+    0 0 3px rgba(255, 0, 0, 0.4),
+    0 0 6px rgba(255, 0, 0, 0.2);
 }
 
 .app-minesweeper__indicator {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 132px;
-  padding: 2px 8px;
-  border: 2px groove #808080;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 2px solid #808080;
+  border-top-color: #ffffff;
+  border-left-color: #ffffff;
+  border-right-color: #404040;
+  border-bottom-color: #404040;
   background: #c0c0c0;
-  font-size: 12px;
-  font-weight: 600;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow:
+    inset -1px -1px 0 #808080,
+    inset 1px 1px 0 #ffffff;
+  margin: 0 auto;
+}
+
+.app-minesweeper__indicator:active {
+  border-top-color: #404040;
+  border-left-color: #404040;
+  border-right-color: #ffffff;
+  border-bottom-color: #ffffff;
+  box-shadow:
+    inset 1px 1px 0 #808080,
+    inset -1px -1px 0 #ffffff;
 }
 
 .app-minesweeper__board-wrapper {
-  flex: 1 1 auto;
+  align-self: center;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 6px;
+  max-width: 100%;
   overflow: auto;
   padding: 6px;
-  border: 2px solid #c0c0c0;
-  background: #808080;
+  border: 2px solid #808080;
+  border-top-color: #ffffff;
+  border-left-color: #ffffff;
+  border-right-color: #404040;
+  border-bottom-color: #404040;
+  background: #c0c0c0;
+  box-shadow:
+    inset 1px 1px 0 #c0c0c0,
+    inset -1px -1px 0 #808080;
+  box-sizing: border-box;
 }
 
 .app-minesweeper__board {
   display: grid;
-  gap: 2px;
+  gap: 1px;
   justify-content: start;
   grid-auto-rows: 24px;
+  padding: 3px;
+  background: #808080;
+  border: 2px solid #808080;
+  border-right-color: #ffffff;
+  border-bottom-color: #ffffff;
+  box-shadow:
+    inset 1px 1px 0 #404040,
+    inset -1px -1px 0 #ffffff;
 }
 
 .app-minesweeper__cell {

--- a/win95sim_v2/tests/phase07-games.test.js
+++ b/win95sim_v2/tests/phase07-games.test.js
@@ -117,15 +117,57 @@ test('minesweeper app mounts board, controls, and cleans up', () => {
       return undefined;
     };
 
-    const toolbar = findByClass(root, 'app-minesweeper__toolbar');
+    const menuBar = findByClass(root, 'app-minesweeper__menubar');
+    const status = findByClass(root, 'app-minesweeper__status');
     const board = findByClass(root, 'app-minesweeper__board');
-    const select = findByClass(root, 'app-minesweeper__select');
-    const button = findByClass(root, 'app-minesweeper__button');
+    const indicator = findByClass(root, 'app-minesweeper__indicator');
+    const gameMenu = findByClass(root, 'app-minesweeper__menu');
 
-    assert.ok(toolbar, 'expected toolbar to render');
+    const findAllByClass = (node, className, acc = []) => {
+      if (!node || !node.children) {
+        return acc;
+      }
+      if (typeof node.className === 'string' && node.className.split(/\s+/).includes(className)) {
+        acc.push(node);
+      }
+      for (const child of node.children) {
+        findAllByClass(child, className, acc);
+      }
+      return acc;
+    };
+
+    assert.ok(menuBar, 'expected menu bar to render');
+    const menuButtons = findAllByClass(menuBar, 'app-minesweeper__menu-item').map((buttonNode) => buttonNode.textContent?.trim());
+    assert.deepEqual(menuButtons, ['Game', 'Help'], 'expected Game and Help menu entries');
+
+    assert.ok(gameMenu, 'expected game menu to exist');
+    const menuOptions = findAllByClass(gameMenu, 'app-minesweeper__menu-option').map((option) => {
+      const difficultyAttr = typeof option.getAttribute === 'function' ? option.getAttribute('data-difficulty') : undefined;
+      const difficulty = difficultyAttr ?? option.dataset?.difficulty ?? null;
+      return {
+        label: findByClass(option, 'app-minesweeper__menu-option-label')?.textContent?.trim(),
+        role: option.getAttribute ? option.getAttribute('role') : undefined,
+        difficulty,
+      };
+    });
+    assert.deepEqual(
+      menuOptions,
+      [
+        { label: 'New', role: 'menuitem', difficulty: null },
+        { label: 'Beginner (9×9, 10 mines)', role: 'menuitemradio', difficulty: 'beginner' },
+        { label: 'Intermediate (16×16, 40 mines)', role: 'menuitemradio', difficulty: 'intermediate' },
+        { label: 'Expert (30×16, 99 mines)', role: 'menuitemradio', difficulty: 'expert' },
+      ],
+      'expected game menu entries for new game and difficulty presets',
+    );
+
+    assert.equal(findByClass(root, 'app-minesweeper__controls'), undefined, 'expected no bottom controls panel');
+
+    assert.ok(status, 'expected status panel to render');
+    assert.ok(status?.parentElement?.className.includes('app-minesweeper__board-wrapper'), 'status should sit inside board frame');
     assert.ok(board, 'expected board to render');
-    assert.ok(select, 'expected difficulty selector');
-    assert.ok(button, 'expected new game button');
+    assert.equal(indicator?.tagName, 'BUTTON', 'status indicator should be a button');
+    assert.equal(indicator?.textContent?.trim(), '🙂', 'status indicator should show ready face');
     assert.ok(board.children.length > 0, 'expected board to contain cells');
 
     app.destroy();


### PR DESCRIPTION
## Summary
- move Minesweeper's difficulty and new game actions into the Game menu with keyboard navigation and DOM-safe cleanup
- tighten the Minesweeper window styling so the chrome hugs the 9×9 grid and add Win95-like dropdown menu visuals
- shrink the default Minesweeper window size and update the phase 07 test expectations for the new menu layout

## Testing
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fec44645588329b7f26e0c05a0daae